### PR TITLE
NOTIFPLT-30 Add ability to Favorite an item

### DIFF
--- a/notification-portlet-api/pom.xml
+++ b/notification-portlet-api/pom.xml
@@ -14,6 +14,10 @@
     <dependencies>
 
         <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
             <version>${jackson.version}</version>

--- a/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationEntry.java
+++ b/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationEntry.java
@@ -28,6 +28,7 @@ import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 
+import org.apache.commons.lang.builder.ToStringBuilder;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.codehaus.jackson.map.annotate.JsonDeserialize;
 
@@ -59,6 +60,7 @@ public class NotificationEntry implements Serializable, Cloneable {
     private Date      dueDate;
     private String    image;
     private String    body;
+    private boolean   favorite;
 
     /*
      * Weakly-typed, open-ended attributes collection
@@ -175,6 +177,14 @@ public class NotificationEntry implements Serializable, Cloneable {
         }
     }
 
+    public boolean isFavorite() {
+        return favorite;
+    }
+
+    public void setFavorite(boolean favorite) {
+        this.favorite = favorite;
+    }
+
     /**
      * Implements deep-copy clone.
      * 
@@ -205,27 +215,7 @@ public class NotificationEntry implements Serializable, Cloneable {
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("NotificationEntry [source=");
-        builder.append(source);
-        builder.append(", title=");
-        builder.append(title);
-        builder.append(", url=");
-        builder.append(url);
-        builder.append(", linkText=");
-        builder.append(linkText);
-        builder.append(", priority=");
-        builder.append(priority);
-        builder.append(", dueDate=");
-        builder.append(dueDate);
-        builder.append(", image=");
-        builder.append(image);
-        builder.append(", body=");
-        builder.append(body);
-        builder.append(", attributes=");
-        builder.append(attributes);
-        builder.append("]");
-        return builder.toString();
+        return ToStringBuilder.reflectionToString(this);
     }
 
 }

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/favorite/FavoriteAction.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/favorite/FavoriteAction.java
@@ -1,0 +1,145 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.notice.action.favorite;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.PortletPreferences;
+import javax.portlet.PortletRequest;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jasig.portlet.notice.NotificationAction;
+import org.jasig.portlet.notice.NotificationEntry;
+
+public final class FavoriteAction extends NotificationAction {
+
+    /**
+     * This INSTANCE is only for convenience -- FAVORITE and UNFAVORITE not singletons.
+     * There may be situations where de-serialization will create additional
+     * instances, and that's okay.
+     */
+    public static final FavoriteAction FAVORITE = new FavoriteAction();
+
+    /**
+     * Stores the Ids of notices marked as favorite.
+     */
+    private static final String FAVORITE_NOTIFICATION_IDS_PREFERENCE =
+            FavoriteAction.class.getName() + ".FAVORITE_NOTIFICATION_IDS_PREFERENCE";
+
+    private static final long serialVersionUID = 1L;
+
+    private final Log log = LogFactory.getLog(getClass());
+
+    /**
+     * Must remain public, no-arg for de-serialization.
+     */
+    public FavoriteAction() {
+        // Set a default label;  most use cases will use the setter and override
+        setLabel("FAVORITE");
+    }
+
+    public FavoriteAction(String label) {
+        setLabel(label);
+    }
+
+    public static final FavoriteAction createFavoriteInstance() {
+        return new FavoriteAction();
+    }
+
+    public static final FavoriteAction createUnfavoriteInstance() {
+        return new FavoriteAction("UNFAVORITE");
+    }
+
+    /**
+     * Invoking a FavoriteAction toggles it.
+     */
+    @Override
+    public void invoke(final ActionRequest req) {
+        final NotificationEntry entry = getTarget();
+        final String notificationId = entry.getId();
+        final Set<String> favoriteNotices = this.getFavoriteNotices(req);
+        if (favoriteNotices.contains(notificationId)) {
+            favoriteNotices.remove(notificationId);
+        } else {
+            favoriteNotices.add(notificationId);
+        }
+        setFavoriteNotices(req, favoriteNotices);
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        final String id = getId();
+        result = prime * result + ((id == null) ? 0 : id.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        // At present, any instance FavoriteAction is equal to another
+        return true;
+    }
+
+    public void removeFavoriteNotices (final PortletRequest req, Set<String> idsToRemove) {
+        Set<String> currentIds = getFavoriteNotices(req);
+        currentIds.removeAll(idsToRemove);
+        setFavoriteNotices(req, currentIds);
+    }
+
+    /*
+     * Non-public API
+     */
+
+    /* package-private */ Set<String> getFavoriteNotices(final PortletRequest req) {
+
+        final HashSet<String> rslt = new HashSet<String>();
+
+        final PortletPreferences prefs = req.getPreferences();
+        final String[] ids = prefs.getValues(FAVORITE_NOTIFICATION_IDS_PREFERENCE, new String[0]);
+
+        for (int i=0; i < ids.length; i++) {
+            rslt.add(ids[i]);
+        }
+        return rslt;
+
+    }
+
+    /* package-private */ void setFavoriteNotices(final PortletRequest req, final Set<String> favoriteNotices) {
+        final String[] ids = favoriteNotices.toArray(new String[favoriteNotices.size()]);
+        final PortletPreferences prefs = req.getPreferences();
+        try {
+            prefs.setValues(FAVORITE_NOTIFICATION_IDS_PREFERENCE, ids);
+            prefs.store();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/favorite/FavoriteNotificationServiceDecorator.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/favorite/FavoriteNotificationServiceDecorator.java
@@ -1,0 +1,151 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.notice.action.favorite;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.EventRequest;
+import javax.portlet.EventResponse;
+import javax.portlet.PortletPreferences;
+import javax.portlet.PortletRequest;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jasig.portlet.notice.INotificationService;
+import org.jasig.portlet.notice.NotificationAction;
+import org.jasig.portlet.notice.NotificationCategory;
+import org.jasig.portlet.notice.NotificationEntry;
+import org.jasig.portlet.notice.NotificationResponse;
+
+/**
+ * This class can be used to add a "favorite" or "snooze" feature to notifications 
+ * that have an id attribute.  By default, notices will be hidden for 365 days 
+ * (effectively permanent).
+ * 
+ * @author James Wennmacher jwennmacher@unicon.net
+ */
+public class FavoriteNotificationServiceDecorator implements INotificationService {
+
+    public static final String FAVORITE_ENABLED_PREFERENCE = "FavoriteNotificationServiceDecorator.enabled";
+    public static final String DEFAULT_FAVORITE_BEHAVIOR = "false";  // The feature is disabled by default
+
+    // Instance members
+    private INotificationService enclosedNotificationService;
+    private final Log log = LogFactory.getLog(getClass());
+
+    public void setEnclosedNotificationService(INotificationService enclosedNotificationService) {
+        this.enclosedNotificationService = enclosedNotificationService;
+    }
+
+    @Override
+    public String getName() {
+        return enclosedNotificationService.getName();
+    }
+
+    @Override
+    public void invoke(ActionRequest req, ActionResponse res, boolean refresh) {
+        enclosedNotificationService.invoke(req, res, refresh);
+    }
+
+    @Override
+    public void collect(EventRequest req, EventResponse res) {
+        enclosedNotificationService.collect(req, res);
+    }
+
+    @Override
+    public NotificationResponse fetch(PortletRequest req) {
+
+        // Just pass through the enclosed collection if this feature is disabled
+        if (!favoritesEnabled(req)) {
+            return enclosedNotificationService.fetch(req);
+        }
+
+        // Build a fresh NotificationResponse based on a deep-copy of the one we enclose
+        NotificationResponse rslt = null;
+        final NotificationResponse sourceResponse = enclosedNotificationService.fetch(req);
+        try {
+            rslt = (NotificationResponse) sourceResponse.clone();
+        } catch (CloneNotSupportedException e) {
+            log.error("Failed to clone() the sourceResponse", e);
+        }
+
+        final Set<String> favoriteNotificationIds = FavoriteAction.FAVORITE.getFavoriteNotices(req);
+        Set<String> potentiallyMissingIds = new HashSet<String>(favoriteNotificationIds);
+
+        // Add and implement the favorite behavior with our copy
+        for (NotificationCategory category : rslt.getCategories()) {
+
+            for (NotificationEntry entry : category.getEntries()) {
+
+                final List<NotificationAction> currentList = entry.getAvailableActions();
+
+                /*
+                 * There are 2 requirements for an entry to be decorated with Favorite behavior:
+                 * 
+                 *   - (1) It must have an id set
+                 *   - (2) It must not have a FavoriteAction already
+                 */
+                if (StringUtils.isNotBlank(entry.getId())) {
+                    // If the id is in the favorites list, set favorite=true and remove the ID from the potentially
+                    // missing set.
+                    if (favoriteNotificationIds.contains(entry.getId())) {
+                        entry.setFavorite(true);
+                        potentiallyMissingIds.remove(entry.getId());
+                    }
+                    if (!currentList.contains(FavoriteAction.FAVORITE)) {
+                        final List<NotificationAction> replacementList = new ArrayList<NotificationAction>(currentList);
+                        replacementList.add(!entry.isFavorite() ?
+                                FavoriteAction.createFavoriteInstance() : FavoriteAction.createUnfavoriteInstance());
+                        entry.setAvailableActions(replacementList);
+                    }
+                }
+            }
+        }
+
+        // If there were no errors from the sources and there were favorite IDs that were not in the results, remove
+        // them so we don't have them build up over time if the user doesn't un-favorite an item that goes away.
+        if (rslt.getErrors().isEmpty() && potentiallyMissingIds.size() > 0) {
+            if (log.isDebugEnabled()) {
+                log.debug("Removing " + potentiallyMissingIds.size() + " unreferenced favorites for user "
+                        + req.getRemoteUser());
+            }
+            FavoriteAction.FAVORITE.removeFavoriteNotices(req, potentiallyMissingIds);
+        }
+        return rslt;
+
+    }
+
+    private boolean favoritesEnabled(PortletRequest request) {
+        PortletPreferences prefs = request.getPreferences();
+        return Boolean.valueOf(prefs.getValue(FAVORITE_ENABLED_PREFERENCE, DEFAULT_FAVORITE_BEHAVIOR));
+    }
+
+    @Override
+    public boolean isValid(PortletRequest req, NotificationResponse previousResponse) {
+        return enclosedNotificationService.isValid(req, previousResponse);
+    }
+
+}

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/controller/NotificationLifecycleController.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/controller/NotificationLifecycleController.java
@@ -34,14 +34,6 @@ import javax.portlet.PortletPreferences;
 import javax.portlet.ResourceRequest;
 import javax.xml.namespace.QName;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.portlet.ModelAndView;
-import org.springframework.web.portlet.bind.annotation.ActionMapping;
-import org.springframework.web.portlet.bind.annotation.EventMapping;
-import org.springframework.web.portlet.bind.annotation.ResourceMapping;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jasig.portlet.notice.INotificationService;
@@ -51,6 +43,13 @@ import org.jasig.portlet.notice.NotificationEntry;
 import org.jasig.portlet.notice.NotificationResponse;
 import org.jasig.portlet.notice.NotificationResult;
 import org.jasig.portlet.notice.util.UsernameFinder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.portlet.ModelAndView;
+import org.springframework.web.portlet.bind.annotation.ActionMapping;
+import org.springframework.web.portlet.bind.annotation.EventMapping;
+import org.springframework.web.portlet.bind.annotation.ResourceMapping;
 
 /**
  * Gathering of notifications requires action and sometimes event phases.  This 
@@ -100,8 +99,9 @@ public class NotificationLifecycleController {
             allEntries.addAll(y.getEntries());
         }
 
-        final Map<String,Object> model = new HashMap<String,Object>(); 
+        final Map<String,Object> model = new HashMap<String,Object>();
         model.put("feed", allEntries);
+        model.put("errors", notifications.getErrors());
         return new ModelAndView("json", model);
 
     }

--- a/notification-portlet-webapp/src/main/resources/demo/demoNotificationResponse.json
+++ b/notification-portlet-webapp/src/main/resources/demo/demoNotificationResponse.json
@@ -1,7 +1,7 @@
 {
     "errors": [
         {
-            "error": "Connection Timeout",
+            "error": "Error example - Connection Timeout",
             "source": "Demo Service"
         }
      ],

--- a/notification-portlet-webapp/src/main/resources/demo/demoNotificationResponse2.json
+++ b/notification-portlet-webapp/src/main/resources/demo/demoNotificationResponse2.json
@@ -1,7 +1,7 @@
 {
     "errors": [
         {
-            "error": "Service Not Available",
+            "error": "Error example - Service Not Available",
             "source": "Demo 2 Service"
         }
     ],

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/context/portlet/notification.xml
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/context/portlet/notification.xml
@@ -44,6 +44,12 @@
      | defined in the parent applicationContext. 
      +-->
     <bean id="rootNotificationService" class="org.jasig.portlet.notice.action.hide.HideNotificationServiceDecorator">
+        <property name="enclosedNotificationService" ref="favoriteNotificationService"/>
+    </bean>
+    <!-- Favorites must process prior to hide (e.g. be wrapped by hide not the other way around) because it discards
+         favorites that are not present in the notifications when there are no errors from any services.
+         If hide occurred first, it might hide something you had marked as favorite and you'd lose your favorite. -->
+    <bean id="favoriteNotificationService" class="org.jasig.portlet.notice.action.favorite.FavoriteNotificationServiceDecorator">
         <property name="enclosedNotificationService" ref="cacheNotificationService"/>
     </bean>
     <bean id="cacheNotificationService" class="org.jasig.portlet.notice.service.CacheNotificationService">

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -88,6 +88,12 @@
                 <value>-1</value>
             </preference>
 
+            <!-- Indicates whether the portlet allows marking an item as favorite. -->
+            <preference>
+                <name>FavoriteNotificationServiceDecorator.enabled</name>
+                <value>false</value>
+            </preference>
+
         </portlet-preferences>
         <supported-processing-event>
             <qname xmlns:x="https://source.jasig.org/schemas/portlet/notification">x:NotificationResult</qname>

--- a/notification-portlet-webapp/src/main/webapp/scripts/jquery.notice.js
+++ b/notification-portlet-webapp/src/main/webapp/scripts/jquery.notice.js
@@ -91,7 +91,7 @@ if (!upnotice.init) {
               var actionElement = actionTemplate.clone();
               actionElement.removeClass('action-template');
               actionElement.toggleClass('hidden');
-              actionElement.find('a').attr('href', actionUrl).html(action.label);
+              actionElement.find('a').attr('href', actionUrl).html(action.label + " ");
               actionElement.appendTo(actionsContainer);
           }
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     </scm>
 
     <properties>
+        <commons.lang>2.6</commons.lang>
         <filters.file>src/main/filters/notifications.properties</filters.file>
         <jackson.version>1.9.11</jackson.version>
         <resource-server.version>1.0.34</resource-server.version>
@@ -41,6 +42,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${commons.lang}</version>
+            </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-aop</artifactId>


### PR DESCRIPTION
Add ability to do favorites. Shows up in the simple list view.

Simple list view does not yet do any filters to show only your favorite items.  The plan is to implement a datatables view for a student jobs portlet that supports favorites and filters. Favorites will be leveraged in this new view.
