### PR TITLE
NOJIRA - Define Notifications constants into API

### DIFF
--- a/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationConstants.java
+++ b/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationConstants.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.notice;
+
+import javax.xml.namespace.QName;
+
+/**
+ * Constants related to notification-portlet-api
+ */
+public final class NotificationConstants {
+
+    public static final String NOTIFICATION_NAMESPACE = "https://source.jasig.org/schemas/portlet/notification";
+
+    public static final String NOTIFICATION_QUERY_LOCAL_NAME = "NotificationQuery";
+    public static final QName NOTIFICATION_QUERY_QNAME = new QName(NOTIFICATION_NAMESPACE, NOTIFICATION_QUERY_LOCAL_NAME);
+    public static final String NOTIFICATION_QUERY_QNAME_STRING = "{" + NOTIFICATION_NAMESPACE + "}" + NOTIFICATION_QUERY_LOCAL_NAME;
+
+    public static final String NOTIFICATION_RESULT_LOCAL_NAME = "NotificationResult";
+    public static final QName NOTIFICATION_RESULT_QNAME = new QName(NOTIFICATION_NAMESPACE, NOTIFICATION_RESULT_LOCAL_NAME);
+    public static final String NOTIFICATION_RESULT_QNAME_STRING = "{" + NOTIFICATION_NAMESPACE + "}" + NOTIFICATION_RESULT_LOCAL_NAME;
+
+}

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/controller/NotificationLifecycleController.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/controller/NotificationLifecycleController.java
@@ -32,13 +32,13 @@ import javax.portlet.EventRequest;
 import javax.portlet.EventResponse;
 import javax.portlet.PortletPreferences;
 import javax.portlet.ResourceRequest;
-import javax.xml.namespace.QName;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jasig.portlet.notice.INotificationService;
 import org.jasig.portlet.notice.NotificationAction;
 import org.jasig.portlet.notice.NotificationCategory;
+import org.jasig.portlet.notice.NotificationConstants;
 import org.jasig.portlet.notice.NotificationEntry;
 import org.jasig.portlet.notice.NotificationResponse;
 import org.jasig.portlet.notice.NotificationResult;
@@ -52,26 +52,16 @@ import org.springframework.web.portlet.bind.annotation.EventMapping;
 import org.springframework.web.portlet.bind.annotation.ResourceMapping;
 
 /**
- * Gathering of notifications requires action and sometimes event phases.  This 
- * controller serves that purpose. 
+ * Gathering of notifications requires action and sometimes event phases.  This
+ * controller serves that purpose.
  */
 @RequestMapping("VIEW")
 public class NotificationLifecycleController {
-    
+
     public static final String DO_EVENTS_PREFERENCE = "NotificationLifecycleController.doEvents";
-    
-    public static final String NOTIFICATION_NAMESPACE = "https://source.jasig.org/schemas/portlet/notification";
-    
-    public static final String NOTIFICATION_QUERY_LOCAL_NAME = "NotificationQuery";
-    public static final QName NOTIFICATION_QUERY_QNAME = new QName(NOTIFICATION_NAMESPACE, NOTIFICATION_QUERY_LOCAL_NAME);
-    public static final String NOTIFICATION_QUERY_QNAME_STRING = "{" + NOTIFICATION_NAMESPACE + "}" + NOTIFICATION_QUERY_LOCAL_NAME;
-    
-    public static final String NOTIFICATION_RESULT_LOCAL_NAME = "NotificationResult";
-    public static final QName NOTIFICATION_RESULT_QNAME = new QName(NOTIFICATION_NAMESPACE, NOTIFICATION_RESULT_LOCAL_NAME);
-    public static final String NOTIFICATION_RESULT_QNAME_STRING = "{" + NOTIFICATION_NAMESPACE + "}" + NOTIFICATION_RESULT_LOCAL_NAME;
-    
+
     private static final String SUCCESS_PATH = "/scripts/success.json";
-    
+
     private final Log log = LogFactory.getLog(getClass());
 
     @Autowired
@@ -107,8 +97,8 @@ public class NotificationLifecycleController {
     }
 
     @ActionMapping(params="action=invokeNotificationService")
-    public void invokeNotificationService(final ActionRequest req, final ActionResponse res, 
-            @RequestParam(value="refresh", required=false) final String doRefresh) 
+    public void invokeNotificationService(final ActionRequest req, final ActionResponse res,
+            @RequestParam(value="refresh", required=false) final String doRefresh)
             throws IOException {
 
         // Notification data services must have the invoke() method called,
@@ -121,24 +111,24 @@ public class NotificationLifecycleController {
         if (doEvents) {
 
             /*
-             * TODO:  I wish we didn't have to go through a whole render phase just 
-             * to trigger the events-based features of the portlet, but atm I don't 
+             * TODO:  I wish we didn't have to go through a whole render phase just
+             * to trigger the events-based features of the portlet, but atm I don't
              * see a way around it, since..
-             * 
+             *
              *   - (1) You can only start an event chain in the Action phase;  and
              *   - (2) You can only return JSON in a Resource phase;  and
-             *   - (3) An un-redirected Action phase leads to a Render phase, not a 
+             *   - (3) An un-redirected Action phase leads to a Render phase, not a
              *     Resource phase :(
-             * 
-             * It would be awesome either (first choice) to do Action > Event > Resource, 
-             * or Action > sendRedirect() followed by a Resource request.  
-             * 
-             * As it stands, this implementation will trigger a complete render on 
+             *
+             * It would be awesome either (first choice) to do Action > Event > Resource,
+             * or Action > sendRedirect() followed by a Resource request.
+             *
+             * As it stands, this implementation will trigger a complete render on
              * the portal needlessly.
              */
 
         } else {
-            // The real payload awaits a Render phase;  send a token response to 
+            // The real payload awaits a Render phase;  send a token response to
             // avoid a full portlet request cycle (since we can).
             final String contextPath = req.getContextPath();
             res.sendRedirect(contextPath + SUCCESS_PATH);
@@ -148,7 +138,7 @@ public class NotificationLifecycleController {
 
     @ActionMapping
     public void invokeUserAction(final ActionRequest req, final ActionResponse res,
-            @RequestParam("notificationId") final String notificationId, 
+            @RequestParam("notificationId") final String notificationId,
             @RequestParam("actionId") final String actionId) {
 
         // Prime the pump
@@ -173,14 +163,14 @@ public class NotificationLifecycleController {
         if (target != null) {
             target.invoke(req);
         } else {
-            String msg = "Target action not found for notificationId='" 
+            String msg = "Target action not found for notificationId='"
                     + notificationId + "' and actionId='" + actionId + "'";
             log.warn(msg);
         }
 
     }
 
-    @EventMapping(NOTIFICATION_RESULT_QNAME_STRING)
+    @EventMapping(NotificationConstants.NOTIFICATION_RESULT_QNAME_STRING)
     public void collectNotifications(final EventRequest req, final EventResponse res) {
 
         final PortletPreferences prefs = req.getPreferences();
@@ -191,8 +181,8 @@ public class NotificationLifecycleController {
         }
 
         if (log.isDebugEnabled()) {
-            log.debug("Processing event=" + NOTIFICATION_RESULT_QNAME_STRING +" for user='" 
-                                + usernameFinder.findUsername(req) 
+            log.debug("Processing event=" + NotificationConstants.NOTIFICATION_RESULT_QNAME_STRING +" for user='"
+                                + usernameFinder.findUsername(req)
                                 + "' and windowId=" + req.getWindowID());
         }
 

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/event/PortletEventNotificationService.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/event/PortletEventNotificationService.java
@@ -35,6 +35,7 @@ import net.sf.ehcache.Element;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jasig.portlet.notice.NotificationConstants;
 import org.jasig.portlet.notice.NotificationQuery;
 import org.jasig.portlet.notice.NotificationResponse;
 import org.jasig.portlet.notice.NotificationResult;
@@ -42,7 +43,7 @@ import org.jasig.portlet.notice.controller.NotificationLifecycleController;
 import org.jasig.portlet.notice.service.AbstractNotificationService;
 
 public final class PortletEventNotificationService extends AbstractNotificationService {
-    
+
     private final NotificationResponse EMPTY_RESPONSE = new NotificationResponse();
 
     private final Log log = LogFactory.getLog(getClass());
@@ -56,7 +57,7 @@ public final class PortletEventNotificationService extends AbstractNotificationS
     @Override
     public void invoke(final ActionRequest req, final ActionResponse res, final boolean refresh) {
 
-        // Since this behavior is potentially a great deal of work for the 
+        // Since this behavior is potentially a great deal of work for the
         // portal, there is a portlet preference required to turn it on -- even
         // if the bean is configured in the context.
         final PortletPreferences prefs = req.getPreferences();
@@ -83,13 +84,13 @@ public final class PortletEventNotificationService extends AbstractNotificationS
 
             if (sendRequestEvent) {
                 if (log.isDebugEnabled()) {
-                    log.debug("REQUESTING Notifications events for user='" 
-                                        + usernameFinder.findUsername(req) 
+                    log.debug("REQUESTING Notifications events for user='"
+                                        + usernameFinder.findUsername(req)
                                         + "' and windowId=" + req.getWindowID());
                 }
                 NotificationQuery query = new NotificationQuery();
                 query.setQueryWindowId(req.getWindowID());
-                res.setEvent(NotificationLifecycleController.NOTIFICATION_QUERY_QNAME, query);
+                res.setEvent(NotificationConstants.NOTIFICATION_QUERY_QNAME, query);
             }
 
         }
@@ -101,8 +102,8 @@ public final class PortletEventNotificationService extends AbstractNotificationS
     public void collect(final EventRequest req, final EventResponse res) {
 
         if (log.isDebugEnabled()) {
-            log.debug("RECEIVING Notifications events for user='" 
-                                + usernameFinder.findUsername(req) 
+            log.debug("RECEIVING Notifications events for user='"
+                                + usernameFinder.findUsername(req)
                                 + "' and windowId=" + req.getWindowID());
         }
 


### PR DESCRIPTION
This is usefull to use Notifications into other portlets
which can provide Notification events.
Warning this commit wasn't tested but should be enougth to provide the
elements needed into another portlet after importing
notification-portlet-api dependency.
