### PR TITLE
NOTIFPLT-38 Adds a read/unread state to notification portlet

### DIFF
--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/read/ReadAction.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/read/ReadAction.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.notice.action.read;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.PortletPreferences;
+import javax.portlet.PortletRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.jasig.portlet.notice.NotificationAction;
+import org.jasig.portlet.notice.NotificationEntry;
+
+public final class ReadAction extends NotificationAction{
+
+    private static final long serialVersionUID = 1L;
+    
+    protected static Logger logger = LoggerFactory.getLogger(ReadAction.class);
+
+    /**
+     * This INSTANCE is only for convenience -- READ and UNREAD not singletons.
+     * There may be situations where de-serialization will create additional
+     * instances, and that's okay.
+     */
+    public static final ReadAction READ = new ReadAction();
+    
+    /**
+     * Stores the Ids of read notices.
+     */
+    private static final String READ_NOTIFICATION_IDS_PREFERENCE = 
+            ReadAction.class.getName() + ".READ_NOTIFICATION_IDS_PREFERENCE";
+    
+    /**
+     * Must remain public, no-arg for de-serialization.
+     */
+    public ReadAction() {
+        // Set a default label;  most use cases will use the setter and override
+        setLabel("MARK AS READ");
+    }
+    
+    public ReadAction(String label){
+        setLabel(label);
+    }
+    
+    public static final ReadAction createReadInstance() {
+        return new ReadAction();
+    }
+
+    public static final ReadAction createUnReadInstance() {
+        return new ReadAction("MARK AS UNREAD");
+    }
+    
+    /**
+     * Invoking a ReadAction toggles it.
+     */
+    @Override
+    public void invoke(final ActionRequest req) {
+        final NotificationEntry entry = getTarget();
+        final String notificationId = entry.getId();
+        final Set<String> readNotices = this.getReadNotices(req);
+        if (readNotices.contains(notificationId)) {
+            readNotices.remove(notificationId);
+        } else {
+            readNotices.add(notificationId);
+        }
+        setReadNotices(req, readNotices);
+    }
+    
+    @Override
+    public int hashCode(){
+        return new HashCodeBuilder(17, 31).
+                append(super.getId()).
+                toHashCode();
+    }
+    
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        // At present, any instance ReadAction is equal to another
+        return true;
+    }
+    
+    public void removeReadNotices (final PortletRequest req, Set<String> idsToRemove) {
+        Set<String> currentIds = getReadNotices(req);
+        currentIds.removeAll(idsToRemove);
+        setReadNotices(req, currentIds);
+    }
+    
+    /*
+     * Non-public API
+     */
+
+    /* package-private */ Set<String> getReadNotices(final PortletRequest req) {
+        final HashSet<String> rslt = new HashSet<String>();
+        final PortletPreferences prefs = req.getPreferences();
+        final String[] ids = prefs.getValues(READ_NOTIFICATION_IDS_PREFERENCE, new String[0]);
+        for (int i=0; i < ids.length; i++) {
+            rslt.add(ids[i]);
+        }
+        return rslt;
+    }
+
+    /* package-private */ void setReadNotices(final PortletRequest req, final Set<String> favoriteNotices) {
+        final String[] ids = favoriteNotices.toArray(new String[favoriteNotices.size()]);
+        final PortletPreferences prefs = req.getPreferences();
+        try {
+            prefs.setValues(READ_NOTIFICATION_IDS_PREFERENCE, ids);
+            prefs.store();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/read/ReadNotificationServiceDecorator.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/read/ReadNotificationServiceDecorator.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to Jasig under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Jasig licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a
+ * copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.notice.action.read;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.EventRequest;
+import javax.portlet.EventResponse;
+import javax.portlet.PortletPreferences;
+import javax.portlet.PortletRequest;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jasig.portlet.notice.INotificationService;
+import org.jasig.portlet.notice.NotificationAction;
+import org.jasig.portlet.notice.NotificationAttribute;
+import org.jasig.portlet.notice.NotificationCategory;
+import org.jasig.portlet.notice.NotificationEntry;
+import org.jasig.portlet.notice.NotificationResponse;
+
+public class ReadNotificationServiceDecorator implements INotificationService {
+
+    public static final String READ_ENABLED_PREFERENCE = "ReadNotificationServiceDecorator.enabled";
+    public static final String DEFAULT_READ_BEHAVIOR = "true";  // The feature is disabled by default
+
+    // Instance members
+    private INotificationService enclosedNotificationService;
+    private final Log log = LogFactory.getLog(getClass());
+
+    public void setEnclosedNotificationService(INotificationService enclosedNotificationService) {
+        this.enclosedNotificationService = enclosedNotificationService;
+    }
+
+    @Override
+    public String getName() {
+        return enclosedNotificationService.getName();
+    }
+
+    @Override
+    public void invoke(ActionRequest req, ActionResponse res, boolean refresh) {
+        enclosedNotificationService.invoke(req, res, refresh);
+    }
+
+    @Override
+    public void collect(EventRequest req, EventResponse res) {
+        enclosedNotificationService.collect(req, res);
+    }
+
+    @Override
+    public NotificationResponse fetch(PortletRequest req) {
+
+        // Just pass through the enclosed collection if this feature is disabled
+        if (!readEnabled(req)) {
+            return enclosedNotificationService.fetch(req);
+        }
+
+        // Build a fresh NotificationResponse based on a deep-copy of the one we enclose
+        NotificationResponse rslt = null;
+        final NotificationResponse sourceResponse = enclosedNotificationService.fetch(req);
+        try {
+            rslt = (NotificationResponse) sourceResponse.clone();
+        } catch (CloneNotSupportedException e) {
+            log.error("Failed to clone() the sourceResponse", e);
+        }
+
+        final Set<String> readNotificationIds = ReadAction.READ.getReadNotices(req);
+        Set<String> potentiallyMissingIds = new HashSet<String>(readNotificationIds);
+
+        NotificationAttribute readAttribute = new NotificationAttribute();
+        readAttribute.setName("read");
+        readAttribute.setValues(new ArrayList<String>(Arrays.asList((new Boolean(true)).toString())));
+        
+        // Add and implement the read behavior with our copy
+        for (NotificationCategory category : rslt.getCategories()) {
+
+            for (NotificationEntry entry : category.getEntries()) {
+
+                final List<NotificationAction> currentList = entry.getAvailableActions();
+
+                /*
+                 * There are 2 requirements for an entry to be decorated with Read behavior:
+                 * 
+                 *   - (1) It must have an id set
+                 *   - (2) It must not have a ReadAction already
+                 */
+                if (StringUtils.isNotBlank(entry.getId())) {
+                    // If the id is in the reads list, set read=true and remove the ID from the potentially
+                    // missing set.
+                    if (readNotificationIds.contains(entry.getId())) {
+                        
+                        List<NotificationAttribute> attributes = new ArrayList<NotificationAttribute>(entry.getAttributes());
+                        attributes.add(readAttribute);
+                        entry.setAttributes(attributes);
+                        potentiallyMissingIds.remove(entry.getId());
+                    }
+                    if (!currentList.contains(ReadAction.READ)) {
+                        final List<NotificationAction> replacementList = new ArrayList<NotificationAction>(currentList);
+                        boolean isMarkedRead = entry.getAttributes().contains(readAttribute);
+                        replacementList.add(!isMarkedRead ?
+                                ReadAction.createReadInstance() : ReadAction.createUnReadInstance());
+                        entry.setAvailableActions(replacementList);
+                    }
+                }
+            }
+        }
+
+        // If there were no errors from the sources and there were read IDs that were not in the results, remove
+        // them so we don't have them build up over time if the user doesn't un-read an item that goes away.
+        if (rslt.getErrors().isEmpty() && potentiallyMissingIds.size() > 0) {
+            if (log.isDebugEnabled()) {
+                log.debug("Removing " + potentiallyMissingIds.size() + " unreferenced reads for user "
+                        + req.getRemoteUser());
+            }
+            ReadAction.READ.removeReadNotices(req, potentiallyMissingIds);
+        }
+        return rslt;
+
+    }
+
+    private boolean readEnabled(PortletRequest request) {
+        PortletPreferences prefs = request.getPreferences();
+        return Boolean.valueOf(prefs.getValue(READ_ENABLED_PREFERENCE, DEFAULT_READ_BEHAVIOR));
+    }
+
+    @Override
+    public boolean isValid(PortletRequest req, NotificationResponse previousResponse) {
+        return enclosedNotificationService.isValid(req, previousResponse);
+    }
+
+}

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/context/portlet/notification.xml
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/context/portlet/notification.xml
@@ -44,6 +44,9 @@
      | defined in the parent applicationContext. 
      +-->
     <bean id="rootNotificationService" class="org.jasig.portlet.notice.action.hide.HideNotificationServiceDecorator">
+        <property name="enclosedNotificationService" ref="readNotificationService"/>
+    </bean>
+    <bean id="readNotificationService" class="org.jasig.portlet.notice.action.read.ReadNotificationServiceDecorator">
         <property name="enclosedNotificationService" ref="favoriteNotificationService"/>
     </bean>
     <!-- Favorites must process prior to hide (e.g. be wrapped by hide not the other way around) because it discards

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -94,6 +94,11 @@
                 <value>false</value>
             </preference>
 
+            <preference>
+                <name>ReadNotificationServiceDecorator.enabled</name>
+                <value>false</value>
+            </preference>
+
         </portlet-preferences>
         <supported-processing-event>
             <qname xmlns:x="https://source.jasig.org/schemas/portlet/notification">x:NotificationResult</qname>


### PR DESCRIPTION
Most of this code is a copy of the hide action / favorite action.

Unlike the hide action, this might not be hidden after read.  This is also permanent unlike hide which has an expiration date.  This is meant to eventually be persisted to a notification store.  Over in this public repo: https://github.com/UW-Madison-DoIT/NotificationPortlet-UWOverlay , we're spinning up a local notification store.  Check out some web services over there!

This is just the start of read/unread action.  Some UI work to follow.

By default this is turned off and this won't change any existing implementations. 
