### PR TITLE
NOTIFPLT-28 update jQuery to 1.10.2

### DIFF
--- a/notification-portlet-webapp/pom.xml
+++ b/notification-portlet-webapp/pom.xml
@@ -202,10 +202,7 @@
                             <groupId>org.jasig.resourceserver</groupId>
                             <artifactId>resource-server-content</artifactId>
                             <includes>
-                                <include>rs/fontawesome/4.0.3/</include>
-                                <include>rs/jquery/1.6.1/</include>
-                                <include>rs/jqueryui/1.8.13/</include>
-                                <include>rs/underscore/1.3.3/</include>
+                                <include>rs/underscore/1.5.2/</include>
                                 <include>rs/bootstrap-namespaced/3.1.1/</include>
                             </includes>
                         </overlay>

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/controller/emergency/EmergencyAlertController.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/controller/emergency/EmergencyAlertController.java
@@ -42,7 +42,7 @@ public final class EmergencyAlertController {
     public static final String VIEW_SHOW_ALERTS = "show-alerts";
 
     private static final String USE_PPORTAL_JS_LIBS_PREFERENCE = "EmergencyAlertController.usePortalJsLibs";
-    private static final String PPORTAL_JS_NAMESPACE_PREFERENCE = "EmergencyAlertController.portalJsNamespace";
+    private static final String PPORTAL_JS_NAMESPACE_PREFERENCE = "portalJsNamespace";
     private static final String AUTO_ADVANCE_PREFERENCE = "EmergencyAlertController.autoAdvance";
 
     private final Log log = LogFactory.getLog(getClass());

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/controller/notification/NotificationIconController.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/controller/notification/NotificationIconController.java
@@ -40,8 +40,8 @@ import org.springframework.web.portlet.bind.annotation.RenderMapping;
 @RequestMapping("VIEW")
 public final class NotificationIconController {
 
-    private static final String USE_PPORTAL_JS_LIBS_PREFERENCE = "EmergencyAlertController.usePortalJsLibs";
-    private static final String PPORTAL_JS_NAMESPACE_PREFERENCE = "EmergencyAlertController.portalJsNamespace";
+    private static final String USE_PPORTAL_JS_LIBS_PREFERENCE = "usePortalJsLibs";
+    private static final String PPORTAL_JS_NAMESPACE_PREFERENCE = "portalJsNamespace";
     private static final String SIZE_PREFERENCE = "NotificationIconController.size";
     private static final String SIZE_DEFAULT = "18";
     private static final String URL_PREFERENCE = "NotificationIconController.url";

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/jsp/accordion.jsp
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/jsp/accordion.jsp
@@ -32,13 +32,10 @@
     <portlet:param name="errorKey" value="ERRORKEY"/>
 </portlet:actionURL>
 
-<script src="<rs:resourceURL value="/rs/jquery/1.6.1/jquery-1.6.1.min.js"/>" type="text/javascript"></script>
-<script src="<rs:resourceURL value="/rs/jqueryui/1.8.13/jquery-ui-1.8.13.min.js"/>" type="text/javascript"></script>
-<script src="<rs:resourceURL value="/rs/underscore/1.3.3/underscore-1.3.3.min.js"/>" type="text/javascript"></script>
-<script src="<c:url value="/scripts/jquery.accordion.min.js"/>" type="text/javascript"></script>
-<script src="<c:url value="/scripts/jquery.notifications.min.js"/>" type="text/javascript"></script>
-
-<link rel="stylesheet" href="<c:url value="/styles/accordion.min.css"/>" type="text/css" media="screen" />
+<c:if test="${portletPreferencesValues['usePortalJsLibs'][0] != 'true'}">
+    <rs:aggregatedResources path="/accordianResources.xml"/>
+</c:if>
+<rs:aggregatedResources path="/accordianLocalResources.xml"/>
 
 <div id="${n}container" class="notification-portlet">
 
@@ -77,12 +74,21 @@
 <!-- call ajax on dynamic portlet id -->
 <script type="text/javascript">
     var ${n} = ${n} || {};
-    ${n}.jQuery = jQuery.noConflict(true);
-    ${n}.jQuery(document).ready(function () { 
-        ${n}.jQuery("#${n}container").notifications({ 
+<c:choose>
+    <c:when test="${portletPreferencesValues['usePortalJsLibs'][0] != 'true'}">
+        ${n}.jQuery = jQuery.noConflict(true);
+        ${n}.underscore = _.noConflict();
+    </c:when>
+    <c:otherwise>
+        ${n}.jQuery = up.jQuery;
+        ${n}.underscore = up._;
+    </c:otherwise>
+</c:choose>
+    ${n}.jQuery(document).ready(
+        notificationsPortletView(${n}.jQuery, "#${n}container", ${n}.underscore, {
             invokeNotificationServiceUrl: '${invokeNotificationServiceUrl}',
             getNotificationsUrl: '<portlet:resourceURL id="GET-NOTIFICATIONS"/>',
             hideErrorUrl: '${hideErrorUrl}'
-        });
-    });
+        })
+    );
 </script>

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/jsp/icon.jsp
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/jsp/icon.jsp
@@ -29,11 +29,11 @@
 </portlet:actionURL>
 
 <c:if test="${!usePortalJsLibs}">
-    <script src="<rs:resourceURL value="/rs/jquery/1.6.1/jquery-1.6.1.min.js"/>" type="text/javascript"></script>
+    <rs:aggregatedResources path="/jQueryResources.xml"/>
 </c:if>
 <script src="<c:url value="/scripts/jquery.notice.min.js"/>" type="text/javascript"></script>
 
-<link rel="stylesheet" href="<rs:resourceURL value="/rs/fontawesome/4.0.3/css/font-awesome.min.css"/>" type="text/css" media="screen" />
+<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.min.css" type="text/css" media="screen" />
 
 <style>
 #${n}notificationIcon {

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/jsp/show-alerts.jsp
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/jsp/show-alerts.jsp
@@ -29,8 +29,7 @@
 </portlet:actionURL>
 
 <c:if test="${!usePortalJsLibs}">
-    <script src="<rs:resourceURL value="/rs/jquery/1.6.1/jquery-1.6.1.min.js"/>" type="text/javascript"></script>
-    <script src="<rs:resourceURL value="/rs/jqueryui/1.8.13/jquery-ui-1.8.13.min.js"/>" type="text/javascript"></script>
+    <rs:aggregatedResources path="/jQueryUIResources.xml"/>
 </c:if>
 <script src="<c:url value="/scripts/jquery.notice.min.js"/>" type="text/javascript"></script>
 

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -99,6 +99,13 @@
                 <value>false</value>
             </preference>
 
+            <!-- If true, notifications will piggyback on the portal's JavaScript library (jQuery).  The needs
+                 of this portlet are very lightweight so we'll default to 'true' in this case. -->
+            <preference>
+                <name>usePortalJsLibs</name>
+                <value>true</value>
+            </preference>
+
         </portlet-preferences>
         <supported-processing-event>
             <qname xmlns:x="https://source.jasig.org/schemas/portlet/notification">x:NotificationResult</qname>
@@ -156,18 +163,15 @@
                 <value>false</value>
             </preference>
 
-            <!-- If true, emergency alerts will piggyback on the portal's 
-                 JavaScript library (jQuery).  The needs of this portlet are 
-                 very lightweight and the portlet runs infrequently, so we'll 
-                 default to 'true' in this case. -->
+            <!-- If true, emergency alerts will piggyback on the portal's JavaScript library (jQuery).  The needs
+                 of this portlet are very lightweight so we'll default to 'true' in this case. -->
             <preference>
                 <name>EmergencyAlertController.usePortalJsLibs</name>
                 <value>true</value>
             </preference>
 
-            <!-- If 'EmergencyAlertController.usePortalJsLibs' is true, this 
-                 value will help find the portal's JavaScript library (jQuery).  
-                 If not, it has no impact. -->
+            <!-- If 'EmergencyAlertController.usePortalJsLibs' is true, this value will help find the portal's
+                 JavaScript library (jQuery).  If not, it has no impact. -->
             <preference>
                 <name>portalJsNamespace</name>
                 <value>up</value>
@@ -253,17 +257,14 @@
                 <value>false</value>
             </preference>
 
-            <!-- If true, emergency alerts will piggyback on the portal's 
-                 JavaScript library (jQuery).  The needs of this portlet are 
-                 very lightweight and the portlet runs infrequently, so we'll 
-                 default to 'true' in this case. -->
+            <!-- If true, notification icon will piggyback on the portal's JavaScript library (jQuery).  The needs
+                 of this portlet are very lightweight so we'll default to 'true' in this case. -->
             <preference>
-                <name>EmergencyAlertController.usePortalJsLibs</name>
+                <name>usePortalJsLibs</name>
                 <value>true</value>
             </preference>
 
-            <!-- If 'EmergencyAlertController.usePortalJsLibs' is true, this 
-                 value will help find the portal's JavaScript library (jQuery).  
+            <!-- If 'usePortalJsLibs' is true, this value will help find the portal's JavaScript library (jQuery).
                  If not, it has no impact. -->
             <preference>
                 <name>portalJsNamespace</name>

--- a/notification-portlet-webapp/src/main/webapp/accordianLocalResources.xml
+++ b/notification-portlet-webapp/src/main/webapp/accordianLocalResources.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<resources xmlns="http://www.jasig.org/uportal/web/skin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.jasig.org/uportal/web/skin https://source.jasig.org/schemas/resource-server/skin-configuration/skin-configuration-v1.2.xsd">
+
+    <js included="plain">scripts/jquery.accordion.js</js>
+    <js included="aggregated">scripts/jquery.accordion.min.js</js>
+
+    <js included="plain">scripts/jquery.notifications.js</js>
+    <js included="aggregated">scripts/jquery.notifications.min.js</js>
+
+    <css included="plain">styles/accordion.css</css>
+    <css included="aggregated">styles/accordion.min.css</css>
+
+    </resources>

--- a/notification-portlet-webapp/src/main/webapp/accordianResources.xml
+++ b/notification-portlet-webapp/src/main/webapp/accordianResources.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<resources xmlns="http://www.jasig.org/uportal/web/skin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.jasig.org/uportal/web/skin https://source.jasig.org/schemas/resource-server/skin-configuration/skin-configuration-v1.2.xsd">
+
+    <js import="true">jQueryUIResources.xml</js>
+
+    <js included="plain" resource="true">/rs/underscore/1.5.2/underscore-1.5.2.js</js>
+    <js included="aggregated" resource="true">/rs/underscore/1.5.2/underscore-1.5.2.min.js</js>
+
+    </resources>

--- a/notification-portlet-webapp/src/main/webapp/jQueryResources.xml
+++ b/notification-portlet-webapp/src/main/webapp/jQueryResources.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<resources xmlns="http://www.jasig.org/uportal/web/skin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.jasig.org/uportal/web/skin https://source.jasig.org/schemas/resource-server/skin-configuration/skin-configuration-v1.2.xsd">
+
+    <js included="plain">//code.jquery.com/jquery-1.10.2.js</js>
+    <js included="aggregated">//code.jquery.com/jquery-1.10.2.min.js</js>
+
+    <!-- Must follow loading of jQuery. Use only if needed. -->
+    <!--<js included="plain">//code.jquery.com/jquery-migrate-1.2.1.js</js>-->
+    <!--<js included="aggregated">//code.jquery.com/jquery-migrate-1.2.1.min.js</js>-->
+
+</resources>

--- a/notification-portlet-webapp/src/main/webapp/jQueryUIResources.xml
+++ b/notification-portlet-webapp/src/main/webapp/jQueryUIResources.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to Jasig under one or more contributor license
+    agreements. See the NOTICE file distributed with this work
+    for additional information regarding copyright ownership.
+    Jasig licenses this file to you under the Apache License,
+    Version 2.0 (the "License"); you may not use this file
+    except in compliance with the License. You may obtain a
+    copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on
+    an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<resources xmlns="http://www.jasig.org/uportal/web/skin" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.jasig.org/uportal/web/skin https://source.jasig.org/schemas/resource-server/skin-configuration/skin-configuration-v1.2.xsd">
+
+    <js import="true">jQueryResources.xml</js>
+
+    <js included="plain">//code.jquery.com/ui/1.10.3/jquery-ui.js</js>
+    <js included="aggregated">//code.jquery.com/ui/1.10.3/jquery-ui.min.js</js>
+
+</resources>

--- a/notification-portlet-webapp/src/main/webapp/scripts/jquery.accordion.js
+++ b/notification-portlet-webapp/src/main/webapp/scripts/jquery.accordion.js
@@ -18,13 +18,13 @@
  */
 
 //
-//  Lightweight accordion jQuery plugin
+//  Lightweight accordion function
 //
 //  Author: Jacob Lichner
 //  Email: jacob.d.lichner@gmail.com
 //
-(function ($) {
-  $.fn.accordion = function (options) {
+
+var notificationsAccordion = notificationsAccordion || function ($, container, options) {
     
     var defaults = {
       trigger   : '.notification-trigger',
@@ -37,8 +37,8 @@
     var opts = $.extend(defaults, options);
     
     // Cache DOM elements
-    var allTriggers = this.children(opts.trigger),
-        allContent  = this.children(opts.content);
+    var allTriggers = container.children(opts.trigger),
+        allContent  = container.children(opts.content);
     
       // Begin accordion
     allTriggers
@@ -97,6 +97,4 @@
       el.stop(true,true)['slide' + direction](opts.speed);          
     }
     
-    return this;
-  }
-})(jQuery);
+};

--- a/notification-portlet-webapp/src/main/webapp/scripts/jquery.notice.js
+++ b/notification-portlet-webapp/src/main/webapp/scripts/jquery.notice.js
@@ -17,12 +17,12 @@
  * under the License.
  */
 
-var upnotice = upnotice || {};
-
 /*
- * This file offers a simple, flexible widget for displaying notifications.  It 
- * is possible to use this script with multiple, different markup approaches. 
+ * This file offers a simple, flexible widget for displaying notifications.  It
+ * is possible to use this script with multiple, different markup approaches.
  */
+
+var upnotice = upnotice || {};
 
 if (!upnotice.init) {
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <filters.file>src/main/filters/notifications.properties</filters.file>
         <jackson.version>1.9.11</jackson.version>
         <logbackVersion>1.0.13</logbackVersion>
-        <resource-server.version>1.0.39</resource-server.version>
+        <resource-server.version>1.0.42</resource-server.version>
         <slf4jVersion>1.7.5</slf4jVersion>
         <spring.version>3.1.3.RELEASE</spring.version>
     </properties>


### PR DESCRIPTION
Also adds
- CDNs for resources for faster load times
- Updated javascript scripts to not use function rather than jQuery plug-in style to not impact and allow using portal's jQuery
- default to usePortalJsLibs=true for efficiency
- RS aggregation resources to allow non-aggregated views for debugging
- misc improvements
