### PR TITLE
NOTIFPLT-69: Marking logger as XMLTransient in NotificationResponse t…

### DIFF
--- a/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationResponse.java
+++ b/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationResponse.java
@@ -49,6 +49,7 @@ public class NotificationResponse implements Serializable, Cloneable {
 
     private static final long serialVersionUID = 1L;
 
+    @XmlTransient
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     private List<NotificationCategory> categories;


### PR DESCRIPTION
https://issues.jasig.org/browse/NOTIFPLT-69

Tracked down the issue to logger not being flagged transient. Difficult to debug as the error thrown was IllegalAnnotationException -- not so helpful.