### PR TITLE
NOTIFPLT-80:  Refactor HideNotificationServiceDecorator to use JPA (d…

### DIFF
--- a/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationAttribute.java
+++ b/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationAttribute.java
@@ -38,16 +38,16 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class NotificationAttribute implements Serializable, Cloneable {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	private String name;
-	private List<String> values = Collections.emptyList();
+    private String name;
+    private List<String> values = Collections.emptyList();
 
-	public NotificationAttribute() {}
+    public NotificationAttribute() {}
 
-	/**
-	 * Shortcut constructor.
-	 */
+    /**
+     * Shortcut constructor.
+     */
     public NotificationAttribute(String name, String value) {
         this(name, Arrays.asList(new String[] { value }));
     }
@@ -57,21 +57,21 @@ public class NotificationAttribute implements Serializable, Cloneable {
         this.values = new ArrayList<String>(values);  // defensive copy
     }
 
-	public String getName() {
-		return name;
-	}
+    public String getName() {
+        return name;
+    }
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	public List<String> getValues() {
-		return Collections.unmodifiableList(values);
-	}
+    public List<String> getValues() {
+        return Collections.unmodifiableList(values);
+    }
 
-	public void setValues(List<String> values) {
-		this.values = new ArrayList<String>(values);  // defensive copy
-	}
+    public void setValues(List<String> values) {
+        this.values = new ArrayList<String>(values);  // defensive copy
+    }
 
     /**
      * Implements deep-copy clone.
@@ -91,7 +91,7 @@ public class NotificationAttribute implements Serializable, Cloneable {
         return rslt;
 
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj){
@@ -128,5 +128,5 @@ public class NotificationAttribute implements Serializable, Cloneable {
         builder.append("]");
         return builder.toString();
     }
-	
+
 }

--- a/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationEntry.java
+++ b/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationEntry.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -204,6 +205,18 @@ public class NotificationEntry implements Serializable, Cloneable {
     @JsonDeserialize(using=JsonAttributesDeserializer.class)
     public void setAttributes(List<NotificationAttribute> attributes) {
         this.attributes = new ArrayList<NotificationAttribute>(attributes);  // defensive copy
+    }
+
+    /**
+     * Convenience method for obtaining the attributes in a more usable collection.
+     */
+    @JsonIgnore
+    public Map<String,List<String>> getAttributesMap() {
+        Map<String,List<String>> rslt = new HashMap<>();
+        for (NotificationAttribute a : attributes) {
+            rslt.put(a.getName(), a.getValues());
+        }
+        return rslt;
     }
 
     /**

--- a/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationResponse.java
+++ b/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationResponse.java
@@ -26,7 +26,6 @@ import java.util.Set;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/notification-portlet-api/src/main/java/org/jasig/portlet/notice/rest/AttributeDTO.java
+++ b/notification-portlet-api/src/main/java/org/jasig/portlet/notice/rest/AttributeDTO.java
@@ -30,7 +30,9 @@ import java.util.List;
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class AttributeDTO implements Serializable {
-    private static final long serialVersionUid = 1l;
+
+    private static final long serialVersionUID = 1L;
+
     private long id;
     private String name;
     private List<String> values = new ArrayList<>();

--- a/notification-portlet-api/src/main/java/org/jasig/portlet/notice/rest/EntryDTO.java
+++ b/notification-portlet-api/src/main/java/org/jasig/portlet/notice/rest/EntryDTO.java
@@ -25,17 +25,18 @@ import java.sql.Timestamp;
 import java.util.HashSet;
 import java.util.Set;
 
-
 /**
  * @author Josh Helmer, jhelmer.unicon.net
  * @since 3.0
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class EntryDTO implements Serializable {
-    private static final long serialVersionUid = 1l;
+
+    private static final long serialVersionUID = 1L;
 
     private long id;
     private String title;
+    private String source;
     private String url;
     private String linkText;
     private int priority;
@@ -46,113 +47,100 @@ public class EntryDTO implements Serializable {
     private Set<ActionDTO> actions = new HashSet<>();
     private Set<AddresseeDTO> addressees = new HashSet<>();
 
-
     public long getId() {
         return id;
     }
-
 
     public void setId(long id) {
         this.id = id;
     }
 
-
     public String getTitle() {
         return title;
     }
-
 
     public void setTitle(String title) {
         this.title = title;
     }
 
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
 
     public String getUrl() {
         return url;
     }
 
-
     public void setUrl(String url) {
         this.url = url;
     }
-
 
     public String getLinkText() {
         return linkText;
     }
 
-
     public void setLinkText(String linkText) {
         this.linkText = linkText;
     }
-
 
     public int getPriority() {
         return priority;
     }
 
-
     public void setPriority(int priority) {
         this.priority = priority;
     }
-
 
     public Timestamp getDueDate() {
         return dueDate;
     }
 
-
     public void setDueDate(Timestamp dueDate) {
         this.dueDate = dueDate;
     }
-
 
     public String getImage() {
         return image;
     }
 
-
     public void setImage(String image) {
         this.image = image;
     }
-
 
     public String getBody() {
         return body;
     }
 
-
     public void setBody(String body) {
         this.body = body;
     }
-
 
     public Set<AttributeDTO> getAttributes() {
         return attributes;
     }
 
-
     public void setAttributes(Set<AttributeDTO> attributes) {
         this.attributes = attributes;
     }
-
 
     public Set<AddresseeDTO> getAddressees() {
         return addressees;
     }
 
-
     public void setAddressees(Set<AddresseeDTO> addressees) {
         this.addressees = addressees;
     }
-
 
     public Set<ActionDTO> getActions() {
         return actions;
     }
 
-
     public void setActions(Set<ActionDTO> actions) {
         this.actions = actions;
     }
+
 }

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/hide/HideAction.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/hide/HideAction.java
@@ -128,7 +128,10 @@ public final class HideAction extends NotificationAction {
             }
         }
 
-        long rslt = Long.parseLong(hideDurationHours) * MILLIS_IN_ONE_HOUR;
+        logger.debug("Calculated hideDurationHours={} for entry with id='{}', title='{}'",
+                                hideDurationHours, entry.getId(), entry.getTitle());
+
+        final long rslt = Long.parseLong(hideDurationHours) * MILLIS_IN_ONE_HOUR;
         return rslt;
 
     }

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/hide/HideAction.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/hide/HideAction.java
@@ -53,7 +53,7 @@ public final class HideAction extends NotificationAction {
 
     private static final long serialVersionUID = 1L;
 
-    private static final Logger logger = LoggerFactory.getLogger(HideAction.class);
+    private final Logger logger = LoggerFactory.getLogger(HideAction.class);
 
     /**
      * Must remain public, no-arg for de-serialization.

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/hide/HideNotificationServiceDecorator.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/hide/HideNotificationServiceDecorator.java
@@ -20,7 +20,6 @@ package org.jasig.portlet.notice.action.hide;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -78,13 +77,13 @@ public class HideNotificationServiceDecorator implements INotificationService {
 
         logger.debug("Processing notifications for username='{}'", req.getRemoteUser());
 
-        // Just pass through the enclosed collection if this feature is disabled
-        if (HideAction.INSTANCE.calculateHideDurationMillis(req) < 0) {
-            logger.debug("Ignoring Hide behavior for username='{}' because the feature is disabled.", req.getRemoteUser());
-            return enclosedNotificationService.fetch(req);
-        }
-
-        logger.debug("Processing Hide behavior for username='{}' because the feature is NOT disabled.", req.getRemoteUser());
+//        // Just pass through the enclosed collection if this feature is disabled
+//        if (HideAction.INSTANCE.calculateHideDurationMillis(req) < 0) {
+//            logger.debug("Ignoring Hide behavior for username='{}' because the feature is disabled.", req.getRemoteUser());
+//            return enclosedNotificationService.fetch(req);
+//        }
+//
+//        logger.debug("Processing Hide behavior for username='{}' because the feature is NOT disabled.", req.getRemoteUser());
 
         /*
          * We will build a fresh NotificationResponse based on a deep-copy of the one we enclose
@@ -117,7 +116,7 @@ public class HideNotificationServiceDecorator implements INotificationService {
                     entry.setAvailableActions(replacementList); // Also sets HideAction.targetEntity
                 }
 
-                if (isEntryHidden(entry, req)) {
+                if (HideAction.INSTANCE.isEntrySnoozed(entry, req)) {
                     logger.debug("Hiding entry with id='{}' for username='{}' based on user's previous action", entry.getId(), req.getRemoteUser());
                     entriesAfterHiding.remove(entry);
                 }
@@ -136,23 +135,6 @@ public class HideNotificationServiceDecorator implements INotificationService {
     @Override
     public boolean isValid(PortletRequest req, NotificationResponse previousResponse) {
         return enclosedNotificationService.isValid(req, previousResponse);
-    }
-
-    /*
-     * Implementation
-     */
-
-    private boolean isEntryHidden(NotificationEntry entry, PortletRequest req) {
-
-
-        /*
-         * There are 2 requirements for an entry to be removed based on it:
-         *
-         *   - (1) It must be hidden by the user
-         *   - (2) We must not be in "display hidden notices" mode (TODO:  Implement!)
-         */
-        final Set<String> currentlyHiddenNotificationIds = HideAction.INSTANCE.getHiddenNoticesMap(req).keySet();
-        return StringUtils.isNotBlank(entry.getId()) && currentlyHiddenNotificationIds.contains(entry.getId());
     }
 
 }

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/hide/HideNotificationServiceDecorator.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/hide/HideNotificationServiceDecorator.java
@@ -77,14 +77,6 @@ public class HideNotificationServiceDecorator implements INotificationService {
 
         logger.debug("Processing notifications for username='{}'", req.getRemoteUser());
 
-//        // Just pass through the enclosed collection if this feature is disabled
-//        if (HideAction.INSTANCE.calculateHideDurationMillis(req) < 0) {
-//            logger.debug("Ignoring Hide behavior for username='{}' because the feature is disabled.", req.getRemoteUser());
-//            return enclosedNotificationService.fetch(req);
-//        }
-//
-//        logger.debug("Processing Hide behavior for username='{}' because the feature is NOT disabled.", req.getRemoteUser());
-
         /*
          * We will build a fresh NotificationResponse based on a deep-copy of the one we enclose
          * 

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/IJpaNotificationRESTService.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/IJpaNotificationRESTService.java
@@ -18,6 +18,7 @@
  */
 package org.jasig.portlet.notice.service.jpa;
 
+import org.jasig.portlet.notice.NotificationEntry;
 import org.jasig.portlet.notice.rest.AddresseeDTO;
 import org.jasig.portlet.notice.rest.EntryDTO;
 import org.jasig.portlet.notice.rest.EventDTO;
@@ -32,8 +33,19 @@ import java.util.Set;
  * @since 3.0
  */
 public interface IJpaNotificationRESTService {
+
     /**
-     * Get the list of notifications.
+     * Get an {@link EntryDTO} by id.
+     */
+    EntryDTO getNotification(long id, boolean full);
+
+    /**
+     * Get an {@link EntryDTO} for a {@link NotificationEntry}, if applicable.
+     */
+    EntryDTO getNotification(NotificationEntry entry, boolean full);
+
+    /**
+     * Get a paged list of all notifications in the data source.
      *
      * @param page 0 based page #
      * @param pageSize page size
@@ -42,13 +54,11 @@ public interface IJpaNotificationRESTService {
     List<EntryDTO> getNotifications(Integer page, Integer pageSize);
 
     /**
-     * Get a notification by id.
-     *
-     * @param id the notification id
-     * @param full if true, will fetch the addressee info as well, otherwise will omit
-     * @return The entry if found, else null
+     * Supports custom integrations and decorators.  Allows another component
+     * within the Notification app to find entries that match a source (a string
+     * representing the other component) and a custom criterion.
      */
-    EntryDTO getNotification(long id, boolean full);
+    List<EntryDTO> getNotificationsBySourceAndCustomAttribute(String source, String attributeName, String attributeValue);
 
     /**
      * Create a notification.
@@ -91,6 +101,14 @@ public interface IJpaNotificationRESTService {
     List<EventDTO> getEventsByNotification(long notificationId);
 
     /**
+     * Get the list of events by notification.
+     *
+     * @param notificationId the notification id
+     * @return the list of events
+     */
+    List<EventDTO> getEventsByNotificationAndUser(long notificationId, String username);
+
+    /**
      * Get a single event.
      *
      * @param eventId the event id
@@ -102,9 +120,9 @@ public interface IJpaNotificationRESTService {
      * Create an event.
      *
      * @param notificationId the notification id
-     * @param entry the entry to create.  Should *NOT* contain an id.
+     * @param event the entry to create.  Should *NOT* contain an id.
      * @return the newly created event
      */
-    EventDTO createEvent(long notificationId, EventDTO entry);
+    EventDTO createEvent(long notificationId, EventDTO event);
 
 }

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/INotificationDao.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/INotificationDao.java
@@ -54,6 +54,8 @@ import org.jasig.portlet.notice.NotificationState;
 
     List<JpaEntry> list(Integer page, Integer pageSize);
 
+    List<JpaEntry> getNotificationsBySourceAndCustomAttribute(String source, String attributeName, String attributeValue);
+
     void removeEntry(JpaEntry entry);
 
     Set<JpaEntry> getEntriesByRecipient(String username);
@@ -68,11 +70,7 @@ import org.jasig.portlet.notice.NotificationState;
 
     /**
      * Provides a complete transaction log for a notification and single
-     * recipient in chronological order.
-     *
-     * @param entryId
-     * @param username
-     * @return
+     * recipient <strong>in chronological order</strong>.
      */
     List<JpaEvent> getEvents(long entryId, String username);
 

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaAction.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaAction.java
@@ -23,6 +23,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 /**
@@ -40,8 +42,9 @@ import javax.persistence.Table;
     @Column(name="ID", nullable = false)
     private long id;
 
-    @Column(name="ENTRY_ID", nullable = false)
-    private long entryId;
+    @ManyToOne
+    @JoinColumn(name="ENTRY_ID")
+    private JpaEntry entry;
 
     @Column(name="LABEL", nullable=false)
     private String label;
@@ -57,12 +60,12 @@ import javax.persistence.Table;
         this.id = id;
     }
 
-    public long getEntryId() {
-        return entryId;
+    public JpaEntry getEntryId() {
+        return entry;
     }
 
-    public void setEntryId(long entryId) {
-        this.entryId = entryId;
+    public void setEntry(JpaEntry entry) {
+        this.entry = entry;
     }
 
     public String getLabel() {
@@ -79,6 +82,11 @@ import javax.persistence.Table;
 
     public void setClazz(String clazz) {
         this.clazz = clazz;
+    }
+
+    @Override
+    public String toString() {
+        return "JpaAction [id=" + id + ", label=" + label + ", clazz=" + clazz + "]";
     }
 
 }

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaAddressee.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaAddressee.java
@@ -32,6 +32,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
@@ -57,8 +58,9 @@ import javax.persistence.Table;
     @Column(name="ID", nullable = false)
     private long id;
 
-    @Column(name="ENTRY_ID", nullable = false)
-    private long entryId;
+    @ManyToOne
+    @JoinColumn(name="ENTRY_ID")
+    private JpaEntry entry;
 
     @Column(name="NAME", nullable=false)
     private String name;
@@ -67,7 +69,6 @@ import javax.persistence.Table;
     private RecipientType type;
 
     @OneToMany(fetch=FetchType.LAZY, cascade=CascadeType.ALL)
-    @JoinColumn(name="ADDRESSEE_ID")
     private Set<JpaRecipient> recipients = new HashSet<JpaRecipient>();
 
     public long getId() {
@@ -78,12 +79,12 @@ import javax.persistence.Table;
         this.id = id;
     }
 
-    public long getEntryId() {
-        return entryId;
+    public JpaEntry getEntryId() {
+        return entry;
     }
 
-    public void setEntryId(long entryId) {
-        this.entryId = entryId;
+    public void setEntry(JpaEntry entry) {
+        this.entry = entry;
     }
 
     public RecipientType getType() {
@@ -114,9 +115,7 @@ import javax.persistence.Table;
      */
     public void setRecipients(Set<JpaRecipient> recipients) {
         this.recipients.clear();
-        for (JpaRecipient recip : recipients) {
-            addRecipient(recip);
-        }
+        this.recipients.addAll(recipients);
     }
 
     /**
@@ -124,6 +123,11 @@ import javax.persistence.Table;
      */
     public void addRecipient(JpaRecipient recipient) {
         recipients.add(recipient);
-        recipient.setAddresseeId(getId());
     }
+
+    @Override
+    public String toString() {
+        return "JpaAddressee [id=" + id + ", name=" + name + ", type=" + type + ", recipients=" + recipients + "]";
+    }
+
 }

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaAttribute.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaAttribute.java
@@ -30,6 +30,8 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 /**
@@ -47,8 +49,9 @@ import javax.persistence.Table;
     @Column(name="ID", nullable = false)
     private long id;
 
-    @Column(name="ENTRY_ID", nullable = false)
-    private long entryId;
+    @ManyToOne
+    @JoinColumn(name="ENTRY_ID")
+    private JpaEntry entry;
 
     @Column(name="NAME", nullable=false)
     private String name;
@@ -66,12 +69,12 @@ import javax.persistence.Table;
         this.id = id;
     }
 
-    public long getEntryId() {
-        return entryId;
+    public JpaEntry getEntryId() {
+        return entry;
     }
 
-    public void setEntryId(long entryId) {
-        this.entryId = entryId;
+    public void setEntry(JpaEntry entry) {
+        this.entry = entry;
     }
 
     public String getName() {
@@ -112,6 +115,11 @@ import javax.persistence.Table;
      */
     public void addValue(int index, String value) {
         values.add(index, value);
+    }
+
+    @Override
+    public String toString() {
+        return "JpaAttribute [id=" + id + ", name=" + name + ", values=" + values + "]";
     }
 
 }

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaAttribute.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaAttribute.java
@@ -69,7 +69,7 @@ import javax.persistence.Table;
         this.id = id;
     }
 
-    public JpaEntry getEntryId() {
+    public JpaEntry getEntry() {
         return entry;
     }
 

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaEntry.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaEntry.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.jasig.portlet.notice.service.jpa;
 
 import java.sql.Timestamp;
@@ -30,7 +31,6 @@ import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
@@ -79,15 +79,12 @@ import javax.persistence.Table;
     private String body;
 
     @OneToMany(fetch=FetchType.EAGER, cascade=CascadeType.ALL)
-    @JoinColumn(name="ENTRY_ID")
     private Set<JpaAttribute> attributes = new HashSet<>();
 
     @OneToMany(fetch=FetchType.EAGER, cascade=CascadeType.ALL)
-    @JoinColumn(name="ENTRY_ID")
     private Set<JpaAction> actions = new HashSet<>();
 
     @OneToMany(fetch=FetchType.LAZY, cascade=CascadeType.ALL)
-    @JoinColumn(name="ENTRY_ID")
     private Set<JpaAddressee> addressees = new HashSet<>();
 
     public long getId() {
@@ -182,9 +179,7 @@ import javax.persistence.Table;
      */
     public void setAttributes(Set<JpaAttribute> attributes) {
         this.attributes.clear();
-        for (JpaAttribute attr : attributes) {
-            addAttribute(attr);
-        }
+        this.attributes.addAll(attributes);
     }
 
     /**
@@ -192,7 +187,6 @@ import javax.persistence.Table;
      */
     public void addAttribute(JpaAttribute attribute) {
         attributes.add(attribute);
-        attribute.setEntryId(getId());
     }
 
     /**
@@ -229,9 +223,7 @@ import javax.persistence.Table;
      */
     public void setAddressees(Set<JpaAddressee> addressees) {
         this.addressees.clear();
-        for (JpaAddressee addressee : addressees) {
-            addAddressee(addressee);
-        }
+        this.addressees.addAll(addressees);
     }
 
     /**
@@ -239,7 +231,14 @@ import javax.persistence.Table;
      */
     public void addAddressee(JpaAddressee addressee) {
         addressees.add(addressee);
-        addressee.setEntryId(getId());
+    }
+
+    @Override
+    public String toString() {
+        return "JpaEntry [id=" + id + ", title=" + title + ", source=" + source + ", category=" + category + ", url="
+                + url + ", linkText=" + linkText + ", priority=" + priority + ", dueDate=" + dueDate + ", image="
+                + image + ", body=" + body + ", attributes=" + attributes + ", actions=" + actions + ", addressees="
+                + addressees + "]";
     }
 
 }

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaEntryPostProcessor.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaEntryPostProcessor.java
@@ -42,17 +42,19 @@ public class JpaEntryPostProcessor implements IMappedClassPostProcessor<JpaEntry
 
     @Override
     public void process(JpaEntry mappedObject, EntryDTO src) {
+
         for (JpaAttribute attr : mappedObject.getAttributes()) {
-            attr.setEntryId(mappedObject.getId());
+            attr.setEntry(mappedObject);
         }
 
         for (JpaAddressee addr : mappedObject.getAddressees()) {
-            addr.setEntryId(mappedObject.getId());
+            addr.setEntry(mappedObject);
             addresseePostProcessor.process(addr, null);
         }
 
         for (JpaAction action : mappedObject.getActions()) {
-            action.setEntryId(mappedObject.getId());
+            action.setEntry(mappedObject);
         }
     }
+
 }

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaNotificationDao.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaNotificationDao.java
@@ -84,6 +84,22 @@ import org.springframework.transaction.annotation.Transactional;
         return query.getResultList();
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public List<JpaEntry> getNotificationsBySourceAndCustomAttribute(String source, String attributeName, String attributeValue) {
+        final String jpql = "SELECT e FROM JpaEntry e "
+                + "WHERE e.source = :source "
+                + "AND EXISTS ("
+                    + "SELECT a FROM JpaAttribute a "
+                    + "WHERE a.entry = e "
+                    + "AND a.name = :name "
+                    + "AND :value MEMBER OF a.values)";
+        final TypedQuery<JpaEntry> query = entityManager.createQuery(jpql, JpaEntry.class);
+        query.setParameter("source", source);
+        query.setParameter("name", attributeName);
+        query.setParameter("value", attributeValue);
+        return query.getResultList();
+    }
 
     @Override
     @Transactional

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaNotificationRESTService.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaNotificationRESTService.java
@@ -86,7 +86,7 @@ public class JpaNotificationRESTService implements IJpaNotificationRESTService {
     @Transactional(readOnly = true)
     public List<EntryDTO> getNotificationsBySourceAndCustomAttribute(String source, String attributeName, String attributeValue) {
         Validate.notBlank(source, "Argument 'source' cannot be blank");
-        Validate.notBlank(source, "Argument 'attributeName' cannot be blank");
+        Validate.notBlank(attributeName, "Argument 'attributeName' cannot be blank");
         // Does it make sense to allow blank attributeValue?
 
         logger.debug("Invoking getNotificationsBySourceAndCustomAttribute with "

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaNotificationService.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaNotificationService.java
@@ -60,10 +60,11 @@ public class JpaNotificationService extends AbstractNotificationService {
      */
     public static final String TABLENAME_PREFIX = "NOTICE_";
 
+    /* package-private */ static final String ID_PREFIX = "jpa_";
+
     private static final NotificationResponse EMPTY_RESPONSE = new NotificationResponse();
     private static final String UNCATEGORIZED_MESSAGE_CODE = "uncategorized";
     private static final String UNCATEGORIZED_DEFAULT_MESSAGE = "(Uncategorized)";
-    private static final String ID_PREFIX = "jpa_";
     private static final String PREFS_ENABLED = "JpaNotificationService.enabled";
 
     @Autowired
@@ -73,6 +74,13 @@ public class JpaNotificationService extends AbstractNotificationService {
     private MessageSource messages;
 
     private final Logger log = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Is the {@link NotificationEntry} object owned by the JPA service?
+     */
+    public boolean contains(NotificationEntry entry) {
+        return entry.getId().startsWith(ID_PREFIX);
+    }
 
     @Override
     public NotificationResponse fetch(PortletRequest req) {
@@ -110,7 +118,7 @@ public class JpaNotificationService extends AbstractNotificationService {
      */
     public void addEntryState(PortletRequest req, String entryId, NotificationState state) {
         if (usernameFinder.isAuthenticated(req)) {
-           
+
             final String username = usernameFinder.findUsername(req);
 
             String idStr = entryId.replaceAll(ID_PREFIX, ""); // remove the prefix

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaRecipient.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaRecipient.java
@@ -23,6 +23,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 /**
@@ -40,8 +42,9 @@ import javax.persistence.Table;
     @Column(name="ID", nullable = false)
     private long id;
 
-    @Column(name="ADDRESSEE_ID", nullable = false)
-    private long addresseeId;
+    @ManyToOne
+    @JoinColumn(name="ADDRESSEE_ID")
+    private JpaAddressee addressee;
 
     @Column(name="USERNAME", nullable=false)
     private String username;
@@ -54,12 +57,12 @@ import javax.persistence.Table;
         this.id = id;
     }
 
-    public long getAddresseeId() {
-        return addresseeId;
+    public JpaAddressee getAddressee() {
+        return addressee;
     }
 
-    public void setAddresseeId(long addresseeId) {
-        this.addresseeId = addresseeId;
+    public void setAddressee(JpaAddressee addressee) {
+        this.addressee = addressee;
     }
 
     public String getUsername() {
@@ -69,4 +72,10 @@ import javax.persistence.Table;
     public void setUsername(String username) {
         this.username = username;
     }
+
+    @Override
+    public String toString() {
+        return "JpaRecipient [id=" + id + ", username=" + username + "]";
+    }
+
 }

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/util/IJpaServices.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/util/IJpaServices.java
@@ -16,23 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.jasig.portlet.notice.service.jpa;
 
-import org.jasig.portlet.notice.rest.AddresseeDTO;
+package org.jasig.portlet.notice.util;
 
-/**
- * Post processor for Handling dozer mappings from AddresseeDTO -&gt; JpaAddressee.
- * Just ensures that the addresseeId value is set in the JPA version.
- *
- * @author Josh Helmer, jhelmer.unicon.net
- * @since 3.0
- */
-public class AddresseePostProcessor implements IMappedClassPostProcessor<JpaAddressee, AddresseeDTO> {
+import java.util.List;
 
-    @Override
-    public void process(JpaAddressee mappedObject, AddresseeDTO srcObject) {
-        for (JpaRecipient recipient : mappedObject.getRecipients()) {
-            recipient.setAddressee(mappedObject);
-        }
-    }
+import org.jasig.portlet.notice.NotificationEntry;
+import org.jasig.portlet.notice.NotificationState;
+import org.jasig.portlet.notice.rest.EventDTO;
+
+public interface IJpaServices {
+
+    List<EventDTO> getHistory(NotificationEntry entry, String username);
+
+    void applyState(NotificationEntry entry, String username, NotificationState state);
+
 }

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/util/JpaServices.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/util/JpaServices.java
@@ -1,0 +1,165 @@
+package org.jasig.portlet.notice.util;
+
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jasig.portlet.notice.NotificationEntry;
+import org.jasig.portlet.notice.NotificationState;
+import org.jasig.portlet.notice.rest.AttributeDTO;
+import org.jasig.portlet.notice.rest.EntryDTO;
+import org.jasig.portlet.notice.rest.EventDTO;
+import org.jasig.portlet.notice.service.jpa.IJpaNotificationRESTService;
+import org.jasig.portlet.notice.service.jpa.JpaNotificationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * This bean allows features and data sources outside of the JPA service
+ * implementation to "piggyback" on some of the persistent capabilities of
+ * the JPA service.
+ *
+ * @author drewwills
+ */
+@Service("jpaServices")
+public class JpaServices implements IJpaServices {
+
+    /**
+     * The {@link HideNotificationServiceDecorator} uses this value as the
+     * <code>source</code> string when masquerading as an external data source
+     * in the JPA system.
+     */
+    private static final String PROXY_SOURCE_NAME = JpaServices.class.getName() + ".PROXY_SOURCE_NAME";
+
+    /**
+     * The {@link HideNotificationServiceDecorator} uses this value to store an
+     * entry's original <code>id</code> as a custom attribute within the JPA
+     * system.
+     */
+    private static final String PROXY_ID_ATTRIBUTE = JpaServices.class.getName() + ".PROXY_ID_ATTRIBUTE";
+
+    /**
+     * Short message WRT what this object is.
+     */
+    private static final String PROXY_BODY_CONTENT = "This is a proxy notification representing "
+                + "one from an external data source;  this strategy supports status changes.";
+
+    @Autowired
+    JpaNotificationService jpaNotificationService;
+
+    @Autowired
+    IJpaNotificationRESTService jpaNotificationRestService;
+
+    private Logger logger = LoggerFactory.getLogger(getClass());
+
+    /**
+     * Provides the known history of status changes for the specified user and
+     * notification <strong>in chronological order</strong>.
+     */
+    @Override
+    public List<EventDTO> getHistory(NotificationEntry entry, String username) {
+
+        List<EventDTO> rslt = Collections.emptyList();  // default
+
+        /*
+         * The JPA system owns status tracking, but it only tracks status for
+         * entries that it owns.  If the entry is not already a JPA-backed
+         * entry, we would use a JPA-side "proxy."
+         */
+        final EntryDTO entryDto = jpaNotificationService.contains(entry)
+                ? jpaNotificationRestService.getNotification(entry, false)
+                : fetchJpaProxyIfAvailable(entry);
+
+        // There can't be history if there isn't (yet) a proxy
+        if (entryDto != null) {
+            rslt = jpaNotificationRestService.getEventsByNotificationAndUser(entryDto.getId(), username);
+        }
+
+        return rslt;
+
+    }
+
+    @Override
+    public void applyState(NotificationEntry entry, String username, NotificationState state) {
+
+        /*
+         * The JPA system owns status tracking, but it only tracks status for
+         * entries that it owns.  If the entry is not already a JPA-backed
+         * entry, we need to create a JPA-side "proxy."
+         */
+        final EntryDTO entryDto = jpaNotificationService.contains(entry)
+                ? jpaNotificationRestService.getNotification(entry, false)
+                : fetchOrCreateJpaProxy(entry);
+
+        final EventDTO event = new EventDTO();
+        event.setState(state);
+        event.setTimestamp(new Timestamp(System.currentTimeMillis()));
+        event.setUsername(username);
+
+        jpaNotificationRestService.createEvent(entryDto.getId(), event);
+
+    }
+
+    /*
+     * Implementation
+     */
+
+    private EntryDTO fetchJpaProxyIfAvailable(NotificationEntry entry) {
+        EntryDTO rslt = null;  // default
+        final List<EntryDTO> list = jpaNotificationRestService.getNotificationsBySourceAndCustomAttribute(
+                PROXY_SOURCE_NAME,
+                PROXY_ID_ATTRIBUTE,
+                entry.getId());
+        logger.debug("Search for JPA-backed entry with id='{}' returned the following:  {}", entry.getId(), list);
+        switch (list.size()) {
+            case 1:
+                // Cool;  we have one...
+                rslt = list.get(0);
+                break;
+            case 0:
+                // Also cool;  we don't have one...
+                break;
+            default:
+                // Not cool...
+                throw new IllegalStateException("More than one JPA-back entry exists for id=" + entry.getId());
+        }
+        return rslt;
+    }
+
+    private EntryDTO fetchOrCreateJpaProxy(NotificationEntry entry) {
+
+        // Try fetch first...
+        EntryDTO rslt = fetchJpaProxyIfAvailable(entry);
+
+        // Otherwise create...
+        if (rslt == null) {
+            final EntryDTO newEntry = new EntryDTO();
+
+            // Important stuff that allows us to identify and retrieve this entry
+            final List<String> values = new ArrayList<>();
+            values.add(entry.getId());
+            final AttributeDTO idAttribute = new AttributeDTO();
+            idAttribute.setName(PROXY_ID_ATTRIBUTE);
+            idAttribute.setValues(values);
+            final Set<AttributeDTO> attributes = new HashSet<>();
+            attributes.add(idAttribute);
+            newEntry.setAttributes(attributes);
+            newEntry.setSource(PROXY_SOURCE_NAME);
+
+            // Just fluff
+            newEntry.setTitle(entry.getTitle());
+            newEntry.setBody(PROXY_BODY_CONTENT);
+
+            rslt = jpaNotificationRestService.createNotification(newEntry);
+        }
+
+        return rslt;
+
+    }
+
+}

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/util/SpringContext.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/util/SpringContext.java
@@ -21,6 +21,7 @@ package org.jasig.portlet.notice.util;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
 
 /**
  * This class provides support for non-Spring managed objects to obtain
@@ -28,9 +29,10 @@ import org.springframework.context.ApplicationContextAware;
  * 
  * @author mglazier
  */
+@Component
 public class SpringContext implements ApplicationContextAware {
 
-	private static ApplicationContext context;
+    private static ApplicationContext context;
 
     @Override
     public void setApplicationContext(ApplicationContext context) throws BeansException {

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/context/applicationContext.xml
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/context/applicationContext.xml
@@ -81,9 +81,6 @@
         <property name="ignoreResourceNotFound" value="true" />
     </bean>
 
-    <!-- Use this to get bean refs from non-Spring managed classes -->
-    <bean id="springContext" class="org.jasig.portlet.notice.util.SpringContext" />
-
     <!--
      | Message source for this application. 
      +-->


### PR DESCRIPTION
…atabase tables) to track hidden notifications instead of Portlet Preferences

https://issues.jasig.org/browse/NOTIFPLT-80

Currently the HideNotificationServiceDecorator uses portlet preferences to track which notices are hidden.  This approach causes problems because each portlet has it's own set of preferences -- e.g. the main 'notification' portlet and the 'notification-icon' portlet.

In other words, when you hide (snooze) a notice in the main portlet it vanishes (for the snooze duration), but the badge number in the notification-icon portlet still includes it (it should decrement by one).

_ALSO_ it would be great, while we're at it, to allow notifications to specify their own snooze duration.