### PR TITLE
NOTIFPLT-81: Change layout of notification header icon and count

### DIFF
--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/controller/notification/NotificationIconController.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/controller/notification/NotificationIconController.java
@@ -30,10 +30,10 @@ import org.springframework.web.portlet.ModelAndView;
 import org.springframework.web.portlet.bind.annotation.RenderMapping;
 
 /**
- * Renders a small notification icon with an ajax-based badge that shows the 
- * current number of botifications.  Clicking on the icon brings up the regular 
+ * Renders a small notification icon with an ajax-based badge that shows the
+ * current number of botifications.  Clicking on the icon brings up the regular
  * Notification portlet.
- * 
+ *
  * @author awills
  */
 @RequestMapping("VIEW")
@@ -42,9 +42,9 @@ public final class NotificationIconController {
     private static final String USE_PPORTAL_JS_LIBS_PREFERENCE = "usePortalJsLibs";
     private static final String PPORTAL_JS_NAMESPACE_PREFERENCE = "portalJsNamespace";
     private static final String ICON_PREFERENCE = "NotificationIconController.faIcon";
-    private static final String ICON_DEFAULT = "fa-warning";
-    private static final String SIZE_PREFERENCE = "NotificationIconController.size";
-    private static final String SIZE_DEFAULT = "18";
+    private static final String ICON_DEFAULT = "fa-bell";
+    private static final String ACTIVE_COLOR_PREFERENCE = "NotificationIconController.activeColor";
+    private static final String ACTIVE_COLOR_DEFAULT = "#d9534f";
     private static final String URL_PREFERENCE = "NotificationIconController.url";
     private static final String URL_DEFAULT = "/uPortal/p/notification";
     private static final String VIEW_NAME = "icon";
@@ -64,8 +64,8 @@ public final class NotificationIconController {
         final String faIcon = prefs.getValue(ICON_PREFERENCE, ICON_DEFAULT);
         model.put("faIcon", faIcon);
 
-        final String size = prefs.getValue(SIZE_PREFERENCE, SIZE_DEFAULT);
-        model.put("size", size);
+        final String activeNotificationColor = prefs.getValue(ACTIVE_COLOR_PREFERENCE, ACTIVE_COLOR_DEFAULT);
+        model.put("activeNotificationColor", activeNotificationColor);
 
         final String url = prefs.getValue(URL_PREFERENCE, URL_DEFAULT);
         model.put("url", url);

--- a/notification-portlet-webapp/src/main/resources/messages.properties
+++ b/notification-portlet-webapp/src/main/resources/messages.properties
@@ -18,7 +18,7 @@
 #
 
 view.notifications=View notifications
-
+notifications=notifications
 alertAdmin.title=Emergency Alert Portlet Administration
 alertAdmin.text=The Emergency Alert portlet is currently
 alertAdmin.enabled=ENABLED

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/jsp/icon.jsp
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/jsp/icon.jsp
@@ -32,41 +32,25 @@
 </c:if>
 <rs:aggregatedResources path="/simpleListLocalResources.xml"/>
 
-<link rel="stylesheet" href="<rs:resourceURL value="/rs/fontawesome/4.0.3/css/font-awesome.min.css"/>" type="text/css" media="screen" />
-
 <style>
-#${n}notificationIcon {
-    display: inline-block;
-}
-#${n}notificationIcon i {
-    font-size: ${size}px;
-}
-#${n}notificationIcon .notification-badge {
-    display: inline-block;
-    background-color: #cb4437;
-    border-radius: 2px;
-    padding: 2px;
-    font: bold 11px Arial;
-    color: #fff;
-    min-width: 15px;
-    position: relative;
-    right: 12px;
-    margin-right: -12px;
-    text-align: center;
-    text-shadow: 0 1px 0 rgba(0,0,0,0.1);
-    top: -${size / 2}px;
-}
+    #${n}notificationIcon .badge {
+        transition: background-color 0.5s;
+    }
+    #${n}notificationIcon .badge.active {
+        background-color: ${activeNotificationColor};
+    }
 </style>
 
 <div id="${n}notificationIcon">
     <a href="${url}" title="<spring:message code="view.notifications"/>">
-        <i class="fa ${faIcon}"></i>
+        <div class="badge" role="alert" aria-live="polite">
+            <i class="fa ${faIcon}" aria-label="<spring:message code="notifications" />"></i>
+            <span class="notification-count"></span>
+        </div>
     </a>
-    <div class="notification-badge" style="display: none;"><span class="notification-count"></span></div>
 </div>
 
 <script type="text/javascript">
-
     var ${n} = ${n} || {};
     <c:choose>
         <c:when test="${!usePortalJsLibs}">
@@ -86,11 +70,12 @@
         }, function(feed) {
             if (feed && feed.length > 0) {
                 $('#${n}notificationIcon .notification-count').html(feed.length);
-                $('#${n}notificationIcon .notification-badge').slideDown();
+                $('#${n}notificationIcon .badge').addClass('active');
+            } else {
+                $('#${n}notificationIcon .notification-count').html('0');
+                $('#${n}notificationIcon .badge').removeClass('active');
             }
         });
 
     });
-
 </script>
-

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -40,20 +40,20 @@
         </portlet-info>
         <portlet-preferences>
 
-            <!-- Locations of static files, in native NotificationPortlet JSON, 
-                 that should be read from the classpath and included in the 
+            <!-- Locations of static files, in native NotificationPortlet JSON,
+                 that should be read from the classpath and included in the
                  response. -->
             <preference>
                 <name>ClassLoaderResourceNotificationService.locations</name>
             </preference>
 
-            <!-- Zero or more URLs for feeds that should be read-in and 
+            <!-- Zero or more URLs for feeds that should be read-in and
                  converted to Notifications by the RomeNotificationService. -->
             <preference>
                 <name>RomeNotificationService.urls</name>
             </preference>
 
-            <!-- Zero or more URLs for web service endpoints for the 
+            <!-- Zero or more URLs for web service endpoints for the
                  RestfulJsonNotificationService. -->
             <preference>
                 <name>RestfulJsonNotificationService.serviceUrls</name>
@@ -87,8 +87,8 @@
                 <read-only>true</read-only>
             </preference>
 
-            <!-- Locations of static files, in native NotificationPortlet JSON, 
-                 that should be read from the classpath and included in the 
+            <!-- Locations of static files, in native NotificationPortlet JSON,
+                 that should be read from the classpath and included in the
                  response FOR THE DEMO EXPERIENCE. -->
             <preference>
                 <name>DemoNotificationService.locations</name>
@@ -127,8 +127,8 @@
                 <name>NotificationLifecycleController.invokeRedirectPort</name>
             </preference>
 
-            <!-- Specifies how long a user-hidden notification should remain 
-                 hidden, in hours.  A value of zero means notifications will be 
+            <!-- Specifies how long a user-hidden notification should remain
+                 hidden, in hours.  A value of zero means notifications will be
                  hidden forever, and any negative value disables the hide feature. -->
             <preference>
                 <name>HideNotificationServiceDecorator.hideDurationHours</name>
@@ -189,27 +189,27 @@
         </portlet-info>
         <portlet-preferences>
 
-            <!-- Locations of static files, in native NotificationPortlet JSON, 
-                 that should be read from the classpath and included in the 
+            <!-- Locations of static files, in native NotificationPortlet JSON,
+                 that should be read from the classpath and included in the
                  response. -->
             <preference>
                 <name>ClassLoaderResourceNotificationService.locations</name>
             </preference>
 
-            <!-- Zero or more URLs for feeds that should be read-in and 
+            <!-- Zero or more URLs for feeds that should be read-in and
                  converted to Notifications by the RomeNotificationService. -->
             <preference>
                 <name>RomeNotificationService.urls</name>
             </preference>
 
-            <!-- Zero or more URLs for web service endpoints for the 
+            <!-- Zero or more URLs for web service endpoints for the
                  RestfulJsonNotificationService. -->
             <preference>
                 <name>RestfulJsonNotificationService.serviceUrls</name>
             </preference>
 
-            <!-- Locations of static files, in native NotificationPortlet JSON, 
-                 that should be read from the classpath and included in the 
+            <!-- Locations of static files, in native NotificationPortlet JSON,
+                 that should be read from the classpath and included in the
                  response FOR THE DEMO EXPERIENCE. -->
             <preference>
                 <name>DemoNotificationService.locations</name>
@@ -256,7 +256,7 @@
                 <value>up</value>
             </preference>
 
-            <!-- If true, emergency alerts will advance on their own (via 
+            <!-- If true, emergency alerts will advance on their own (via
                  JavaScript) when there are more than one to display. -->
             <preference>
                 <name>EmergencyAlertController.autoAdvance</name>
@@ -315,20 +315,20 @@
         </portlet-info>
         <portlet-preferences>
 
-            <!-- Locations of static files, in native NotificationPortlet JSON, 
-                 that should be read from the classpath and included in the 
+            <!-- Locations of static files, in native NotificationPortlet JSON,
+                 that should be read from the classpath and included in the
                  response. -->
             <preference>
                 <name>ClassLoaderResourceNotificationService.locations</name>
             </preference>
 
-            <!-- Zero or more URLs for feeds that should be read-in and 
+            <!-- Zero or more URLs for feeds that should be read-in and
                  converted to Notifications by the RomeNotificationService. -->
             <preference>
                 <name>RomeNotificationService.urls</name>
             </preference>
 
-            <!-- Zero or more URLs for web service endpoints for the 
+            <!-- Zero or more URLs for web service endpoints for the
                  RestfulJsonNotificationService. -->
             <preference>
                 <name>RestfulJsonNotificationService.serviceUrls</name>
@@ -362,8 +362,8 @@
                 <read-only>true</read-only>
             </preference>
 
-            <!-- Locations of static files, in native NotificationPortlet JSON, 
-                 that should be read from the classpath and included in the 
+            <!-- Locations of static files, in native NotificationPortlet JSON,
+                 that should be read from the classpath and included in the
                  response FOR THE DEMO EXPERIENCE. -->
             <preference>
                 <name>DemoNotificationService.locations</name>
@@ -410,17 +410,17 @@
                 <value>up</value>
             </preference>
 
+            <!-- Set the background color shown when there is an active notification -->
+            <preference>
+                <name>NotificationIconController.activeColor</name>
+                <value>#d9534f</value>
+            </preference>
+
             <!-- Set the Font Awesome icon name to use for the Notifications icon.
                  Example values are 'fa-warning', 'fa-envelope'. -->
             <preference>
                 <name>NotificationIconController.faIcon</name>
-                <value>fa-warning</value>
-            </preference>
-
-            <!-- Used for both width and height of the icon. -->
-            <preference>
-                <name>NotificationIconController.size</name>
-                <value>18</value>
+                <value>fa-bell</value>
             </preference>
 
             <!-- Used for both width and height of the icon. -->


### PR DESCRIPTION
https://issues.jasig.org/browse/NOTIFPLT-81

Changes layout to a bootstrap badge, with icon and text adjacent to each
other.
Switches default icon to bell.
Removes size setting and instead inherits surrounding size.
Adds active notification color setting to highlight when there are
notifications.

New layout:
![screencapture-localhost-8080-uportal-p-notification-ctf3-max-render-up-1485987557823](https://cloud.githubusercontent.com/assets/3107513/22529613/55c904da-e895-11e6-9460-cd0ac6c4e7da.png)
![screencapture-localhost-8080-uportal-p-notification-ctf3-max-render-up-1485987572368](https://cloud.githubusercontent.com/assets/3107513/22529614/55cb2ea4-e895-11e6-9deb-bafe59c3a034.png)
