### PR TITLE
NOTIFPLT-87:  Implement a FilteringNotificationServiceDecorator that …

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,40 @@ This is a [Sponsored Portlet][] in the uPortal project.
 
 ## Configuration
 
-See also [documentation in the external wiki][Notifications portlet in Confluence].
+See also the [legacy documentation in the external wiki][].
 
-### Using Encrypted Property Values
+### Java Properties
 
-You may optionally provide sensitive configuration items -- such as database passwords -- in encrypted format.  Use the [Jasypt CLI Tools](http://www.jasypt.org/cli.html) to encrypt the sensitive value, then include it in a `.properties` file like this:
+Some configuration settings for the Notification portlet are managed in Java properties files that
+are loaded by a Spring `PropertySourcesPlaceholderConfigurer`.  (Other settings are data, managed in
+the "portlet publication record" a.k.a. `portlet-definition.xml` file;  these are covered elsewhere
+in this doc.)
+
+The properties files that are sourced by Spring are:
+
+  - `classpath:datasource.properties`
+  - `classpath:configuration.properties`
+  - `file:${portal.home}/global.properties`
+  - `file:${portal.home}/notification.properties`
+
+For a definitive, comprehensive list of these settings you must look inside `datasource.properties`
+and `configuration.properties`.  (This `README` may be incomplete and/or out of date.)
+
+#### The `portal.home` Directory
+
+uPortal version 5 uses a directory called `portal.home` for properties files that live outside of
+-- and have the ability to _override_ properties files within-- the webapp in Tommcat.  Please
+review the [README file for uPortal-Start][] for more information on this sytem.
+
+The Notification portlet sources the shared `global.properties` file, as well as it's own (private)
+file called `notification.properties` in the `portal.home` directory.
+
+#### Using Encrypted Property Values
+
+Within the properties files that are sourced by Spring, you may optionally provide sensitive
+configuration items -- such as database passwords -- in encrypted format.  Use the
+[Jasypt CLI Tools][] to encrypt the sensitive value, then include it in a `.properties` file
+like this:
 
 ```
 hibernate.connection.password=ENC(9ffpQXJi/EPih9o+Xshm5g==)
@@ -19,7 +48,42 @@ hibernate.connection.password=ENC(9ffpQXJi/EPih9o+Xshm5g==)
 
 Specify the encryption key using the `UP_JASYPT_KEY` environment variable.
 
-### [Modal Notification](notification-portlet-webapp/docs/modal.md)
+### Publication Data
+
+Besides Java properties, some configuration settings are managed as data in the _Portlet Publication
+Record_ (the `portlet-definition.xml` file in uPortal).  These settings are defined on a per-
+publication basis, so you can have several publications of the same portlet with each of them
+configured differently.
+
+#### Filtering
+
+You can filter the notices that come from data sources in the publication record.  Use the following
+portlet preferences to _exclude_ some notices from appearing in the display:
+
+<table>
+  <tr>
+    <th>Portlet Preference</th>
+    <th>Possible Value(s)</th>
+  </tr>
+  <tr>
+    <td>FilteringNotificationServiceDecorator.minPriority</td>
+    <td>Number between 1 and 5</td>
+  </tr>
+  <tr>
+    <td>FilteringNotificationServiceDecorator.maxPriority</td>
+    <td>Number between 1 and 5</td>
+  </tr>
+  <tr>
+    <td>FilteringNotificationServiceDecorator.requiredRole</td>
+    <td>
+      Either 'true' or 'false'; a value of 'true' enables role checking, but a notice must define an
+      attribute named 'org.jasig.portlet.notice.service.filter.RequiredRoleNotificationFilter.requiredRole'
+      to be subject to filtering.
+    </td>
+  </tr>
+</table>
+
+### [Modal Notifications][]
 
 The `modal` display strategy presents notices in a Bootstrap modal dialog.  If the notice 
 defines actions, they will be rendered as buttons at the bottom of the dialog;  any button
@@ -29,5 +93,7 @@ This feature could be used for a Terms of Service pop-up that must be accepted b
 accessing the portal.
 
 [Sponsored Portlet]: https://wiki.jasig.org/display/PLT/Jasig+Sponsored+Portlets
-
-[Notifications portlet in Confluence]: https://wiki.jasig.org/pages/viewpage.action?pageId=47875986
+[legacy documentation in the external wiki]: https://wiki.jasig.org/pages/viewpage.action?pageId=47875986
+[README file for uPortal-Start]: https://github.com/Jasig/uPortal-start/blob/master/README.md
+[Jasypt CLI Tools]: http://www.jasypt.org/cli.html
+[Modal Notifications]: notification-portlet-webapp/docs/modal.md

--- a/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationCategory.java
+++ b/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationCategory.java
@@ -45,7 +45,7 @@ public class NotificationCategory implements Serializable, Cloneable {
 	 * Constructor.
 	 */
 	public NotificationCategory() {
-	    entries = new ArrayList<NotificationEntry>();
+	    entries = new ArrayList<>();
 	}
 
 	/**
@@ -53,7 +53,7 @@ public class NotificationCategory implements Serializable, Cloneable {
 	 */
 	public NotificationCategory(String title, List<NotificationEntry> entries) {
 		this.title = title;
-		this.entries = new ArrayList<NotificationEntry>(entries);  // defensive copy
+		this.entries = new ArrayList<>(entries);  // defensive copy
 	}
 
 	public String getTitle() {
@@ -69,7 +69,7 @@ public class NotificationCategory implements Serializable, Cloneable {
 	}
 
 	public void setEntries(List<NotificationEntry> entries) {
-		this.entries = new ArrayList<NotificationEntry>(entries);
+		this.entries = new ArrayList<>(entries);
 	}	                            
 
 	public void addEntries(List<NotificationEntry> newEntries) {
@@ -89,7 +89,7 @@ public class NotificationCategory implements Serializable, Cloneable {
         final NotificationCategory rslt = (NotificationCategory) super.clone();
 
         // Adjust to satisfy deep-copy strategy
-        List<NotificationEntry> eList = new ArrayList<NotificationEntry>(entries.size());
+        List<NotificationEntry> eList = new ArrayList<>(entries.size());
         for (NotificationEntry entry : entries) {
             eList.add((NotificationEntry) entry.clone());
         }

--- a/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationEntry.java
+++ b/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationEntry.java
@@ -212,7 +212,7 @@ public class NotificationEntry implements Serializable, Cloneable {
 
     @JsonDeserialize(using=JsonAttributesDeserializer.class)
     public void setAttributes(List<NotificationAttribute> attributes) {
-        this.attributes = new ArrayList<NotificationAttribute>(attributes);  // defensive copy
+        this.attributes = new ArrayList<>(attributes);  // defensive copy
     }
 
     /**
@@ -238,7 +238,7 @@ public class NotificationEntry implements Serializable, Cloneable {
     }
 
     public void setAvailableActions(List<NotificationAction> availableActions) {
-        this.availableActions = new ArrayList<NotificationAction>();  // defensive copy
+        this.availableActions = new ArrayList<>();  // defensive copy
         for (NotificationAction action : availableActions) {
             // We must make ourself the target of any 
             // action at the time it becomes attached
@@ -263,7 +263,7 @@ public class NotificationEntry implements Serializable, Cloneable {
      * @since 2.2
      */
     public void setStates(Map<NotificationState,Date> states) {
-        this.states = new HashMap<NotificationState,Date>(states);  // defensive copy
+        this.states = new HashMap<>(states);  // defensive copy
     }
 
     /**
@@ -279,12 +279,12 @@ public class NotificationEntry implements Serializable, Cloneable {
         final NotificationEntry rslt = (NotificationEntry) super.clone();
 
         // Adjust to satisfy deep-copy strategy
-        List<NotificationAttribute> atrList = new ArrayList<NotificationAttribute>(attributes.size());
+        List<NotificationAttribute> atrList = new ArrayList<>(attributes.size());
         for (NotificationAttribute attr : attributes) {
             atrList.add((NotificationAttribute) attr.clone());
         }
         rslt.setAttributes(atrList);
-        List<NotificationAction> actList = new ArrayList<NotificationAction>(availableActions.size());
+        List<NotificationAction> actList = new ArrayList<>(availableActions.size());
         for (NotificationAction action : availableActions) {
             actList.add((NotificationAction) action.clone());
         }

--- a/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationEntry.java
+++ b/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationEntry.java
@@ -51,6 +51,14 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class NotificationEntry implements Serializable, Cloneable {
 
+    /**
+     * The <code>priority</code> field of a {@link NotificationEntry} will contain this value when
+     * the priority is unspecified by the source.
+     *
+     * @since 3.1
+     */
+    public static final int PRIORITY_UNSPECIFIED = 0;
+
     private static final long serialVersionUID = 1L;
 
     /*

--- a/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationResponse.java
+++ b/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationResponse.java
@@ -64,8 +64,8 @@ public class NotificationResponse implements Serializable, Cloneable {
     private boolean cloned = false;
 
     public NotificationResponse() {
-        categories = new ArrayList<NotificationCategory>();
-        errors = new ArrayList<NotificationError>();
+        categories = new ArrayList<>();
+        errors = new ArrayList<>();
     }
 
     public NotificationResponse(NotificationResponse response) {
@@ -73,8 +73,8 @@ public class NotificationResponse implements Serializable, Cloneable {
     }
 
     public NotificationResponse(List<NotificationCategory> categories, List<NotificationError> errors) {
-        this.categories = new ArrayList<NotificationCategory>(categories);  // defensive copy
-        this.errors = new ArrayList<NotificationError>(errors);  // defensive copy
+        this.categories = new ArrayList<>(categories);  // defensive copy
+        this.errors = new ArrayList<>(errors);  // defensive copy
     }
 
     public List<NotificationCategory> getCategories() {
@@ -82,7 +82,7 @@ public class NotificationResponse implements Serializable, Cloneable {
     }
 
     public void setCategories(List<NotificationCategory> categories) {
-        this.categories = new ArrayList<NotificationCategory>(categories);  // defensive copy
+        this.categories = new ArrayList<>(categories);  // defensive copy
     }
 
     public List<NotificationError> getErrors() {
@@ -90,7 +90,7 @@ public class NotificationResponse implements Serializable, Cloneable {
     }
 
     public void setErrors(List<NotificationError> errors) {
-        this.errors = new ArrayList<NotificationError>(errors); // defensive copy
+        this.errors = new ArrayList<>(errors); // defensive copy
     }
 
     /**
@@ -147,7 +147,7 @@ public class NotificationResponse implements Serializable, Cloneable {
      */
     public NotificationResponse filterErrors(Set<Integer> hiddenErrorKeys) {
         NotificationResponse rslt = new NotificationResponse(this);
-        List<NotificationError> filteredErrors = new ArrayList<NotificationError>();
+        List<NotificationError> filteredErrors = new ArrayList<>();
         for (NotificationError r : errors) {
             if (!hiddenErrorKeys.contains(r.getKey())) {
                 filteredErrors.add(r);
@@ -181,12 +181,12 @@ public class NotificationResponse implements Serializable, Cloneable {
         final NotificationResponse rslt = (NotificationResponse) super.clone();
 
         // Adjust to satisfy deep-copy strategy
-        List<NotificationCategory> cList = new ArrayList<NotificationCategory>(categories.size());
+        List<NotificationCategory> cList = new ArrayList<>(categories.size());
         for (NotificationCategory category : categories) {
             cList.add((NotificationCategory) category.clone());
         }
         rslt.setCategories(cList);
-        List<NotificationError> eList = new ArrayList<NotificationError>(errors.size());
+        List<NotificationError> eList = new ArrayList<>(errors.size());
         for (NotificationError error : errors) {
             eList.add((NotificationError) error.clone());
         }
@@ -248,4 +248,5 @@ public class NotificationResponse implements Serializable, Cloneable {
     private void setCloned(boolean cloned) {
         this.cloned = cloned;
     }
+
 }

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/favorite/FavoriteNotificationServiceDecorator.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/favorite/FavoriteNotificationServiceDecorator.java
@@ -91,7 +91,7 @@ public class FavoriteNotificationServiceDecorator implements INotificationServic
         NotificationResponse rslt = sourceResponse.cloneIfNotCloned();
 
         final Set<String> favoriteNotificationIds = FavoriteAction.FAVORITE.getFavoriteNotices(req);
-        Set<String> potentiallyMissingIds = new HashSet<String>(favoriteNotificationIds);
+        Set<String> potentiallyMissingIds = new HashSet<>(favoriteNotificationIds);
 
         // Add and implement the favorite behavior with our copy
         for (NotificationCategory category : rslt.getCategories()) {
@@ -110,13 +110,13 @@ public class FavoriteNotificationServiceDecorator implements INotificationServic
                     // If the id is in the favorites list, set favorite=true and remove the ID from the potentially
                     // missing set.
                     if (favoriteNotificationIds.contains(entry.getId())) {
-                        Map<NotificationState,Date> states = new HashMap<NotificationState,Date>(entry.getStates());
+                        Map<NotificationState,Date> states = new HashMap<>(entry.getStates());
                         states.put(NotificationState.FAVORITED, null);
                         entry.setStates(states);
                         potentiallyMissingIds.remove(entry.getId());
                     }
                     if (!currentList.contains(FavoriteAction.FAVORITE)) {
-                        final List<NotificationAction> replacementList = new ArrayList<NotificationAction>(currentList);
+                        final List<NotificationAction> replacementList = new ArrayList<>(currentList);
                         replacementList.add(!entry.getStates().keySet().contains(NotificationState.FAVORITED) ?
                                 FavoriteAction.createFavoriteInstance() : FavoriteAction.createUnfavoriteInstance());
                         entry.setAvailableActions(replacementList);

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/controller/emergency/EmergencyAlertAdminController.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/controller/emergency/EmergencyAlertAdminController.java
@@ -34,7 +34,7 @@ import org.springframework.web.portlet.bind.annotation.RenderMapping;
 @RequestMapping("VIEW")
 public final class EmergencyAlertAdminController {
 
-    @Resource(name="demoEmergencyAlerts")
+    @Resource(name="demoEmergencyAlertsInnerBean")
     private DemoNotificationService notificationService;  // Reference the concrete class b/c we need the extra methods
     
     /*

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/AbstractNotificationService.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/AbstractNotificationService.java
@@ -79,8 +79,13 @@ public abstract class AbstractNotificationService implements INotificationServic
     protected UsernameFinder usernameFinder;
 
     protected final String createServiceUserWindowSpecificCacheKey(PortletRequest req) {
-        // Use the username combined with the name given to this Notification 
-        // service (until we discover a reason that's not good enough).
+        /*
+         * Cache keys are specific to (all of the below)...
+         *
+         *   - Service Name
+         *   - Username
+         *   - Portlet WindowId
+         */
         final StringBuilder rslt = new StringBuilder();
         rslt.append(getName()).append("|").append(usernameFinder.findUsername(req))
                                         .append("|").append(req.getWindowID());

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/filter/FilteringNotificationServiceDecorator.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/filter/FilteringNotificationServiceDecorator.java
@@ -1,0 +1,180 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.notice.service.filter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.EventRequest;
+import javax.portlet.EventResponse;
+import javax.portlet.PortletRequest;
+
+import org.jasig.portlet.notice.INotificationService;
+import org.jasig.portlet.notice.NotificationCategory;
+import org.jasig.portlet.notice.NotificationEntry;
+import org.jasig.portlet.notice.NotificationResponse;
+import org.jasig.portlet.notice.util.UsernameFinder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * This {@link INotificationService} reduces the number of notices shown based on filtering rules.
+ * For example, 'show only notices of priority 1' or 'show only notices in the Library category'.
+ *
+ * @since 3.1
+ */
+public class FilteringNotificationServiceDecorator implements INotificationService  {
+
+    private static final String[] EMPTY_STRING_ARRAY = new String[0];
+
+    private enum FilterMapper {
+
+        MINIMUM_PRIORITY {
+            private static final String PREFERENCE_NAME = "FilteringNotificationServiceDecorator.minPriority";
+
+            @Override
+            Set<INotificationFilter> fromPortletRequest(PortletRequest req) {
+                final String[] preferenceValues = req.getPreferences().getValues(PREFERENCE_NAME, EMPTY_STRING_ARRAY);
+                if (preferenceValues.length != 0) {
+                    // We only support the first value...
+                    int priority = Integer.valueOf(preferenceValues[0]);
+                    return Collections.singleton((INotificationFilter) new MinimumPriorityNotificationFilter(priority));
+                } else {
+                    return Collections.emptySet();
+                }
+            }
+        },
+
+        MAXIMUM_PRIORITY {
+            private static final String PREFERENCE_NAME = "FilteringNotificationServiceDecorator.maxPriority";
+
+            @Override
+            Set<INotificationFilter> fromPortletRequest(PortletRequest req) {
+                final String[] preferenceValues = req.getPreferences().getValues(PREFERENCE_NAME, EMPTY_STRING_ARRAY);
+                if (preferenceValues.length != 0) {
+                    // We only support the first value...
+                    int priority = Integer.valueOf(preferenceValues[0]);
+                    return Collections.singleton((INotificationFilter) new MaximumPriorityNotificationFilter(priority));
+                } else {
+                    return Collections.emptySet();
+                }
+            }
+        };
+
+        abstract Set<INotificationFilter> fromPortletRequest(PortletRequest req);
+
+    }
+
+    // Instance members
+    private INotificationService enclosedNotificationService;
+
+    @Autowired
+    private UsernameFinder usernameFinder;
+
+    private Logger logger = LoggerFactory.getLogger(getClass());
+
+    public void setEnclosedNotificationService(INotificationService enclosedNotificationService) {
+        this.enclosedNotificationService = enclosedNotificationService;
+    }
+
+    @Override
+    public String getName() {
+        return enclosedNotificationService.getName();
+    }
+
+    @Override
+    public void invoke(ActionRequest req, ActionResponse res, boolean refresh) {
+        enclosedNotificationService.invoke(req, res, refresh);
+    }
+
+    @Override
+    public void collect(EventRequest req, EventResponse res) {
+        enclosedNotificationService.collect(req, res);
+    }
+
+
+    @Override
+    public NotificationResponse fetch(PortletRequest req) {
+
+        final NotificationResponse unfilteredResponse = enclosedNotificationService.fetch(req);
+
+        // Gather the filters...
+        final Set<INotificationFilter> filters = new HashSet<>();
+        for (FilterMapper mapper : FilterMapper.values()) {
+            filters.addAll(mapper.fromPortletRequest(req));
+        }
+
+        if (filters.size() == 0) {
+            // Probably the most common scenario...
+            logger.debug("No INotificationFilter objects apply to notifications for "
+                    + "username='{}' and windowID='{}'",
+                    usernameFinder.findUsername(req), req.getWindowID());
+            return unfilteredResponse;
+        } else {
+            logger.debug("Found the following INotificationFilter objects for username='{}' "
+                    + "and windowID='{}':  {}", usernameFinder.findUsername(req),
+                    req.getWindowID(), filters);
+            /*
+             * We need to slice, dice, and reconstruct the response.  This process involves a
+             * number of nested loops, and may not scale well.  The output should probably be
+             * cached.
+             */
+            final List<NotificationCategory> filteredCategories = new ArrayList<>();
+            for (NotificationCategory unfilteredCategory : unfilteredResponse.getCategories()) {
+                final List<NotificationEntry> filteredEntries = new ArrayList<>();
+                for (NotificationEntry entry : unfilteredCategory.getEntries()) {
+                    boolean excluded = false; // until we know otherwise...
+                    for (INotificationFilter filter : filters) {
+                        if (!filter.doFilter(unfilteredCategory, entry)) {
+                            excluded = true;
+                            break;
+                        }
+                    }
+                    if (!excluded) {
+                        filteredEntries.add(entry);
+                    }
+                }
+                if (filteredEntries.size() != 0) {
+                    final NotificationCategory category = new NotificationCategory();
+                    category.setTitle(unfilteredCategory.getTitle());
+                    category.setEntries(filteredEntries);
+                    filteredCategories.add(category);
+                }
+            }
+            final NotificationResponse rslt = new NotificationResponse();
+            rslt.setCategories(filteredCategories);
+            rslt.setErrors(unfilteredResponse.getErrors());
+            return rslt;
+        }
+
+    }
+
+    @Override
+    public boolean isValid(PortletRequest req, NotificationResponse previousResponse) {
+        return enclosedNotificationService.isValid(req, previousResponse);
+    }
+
+}

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/filter/INotificationFilter.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/filter/INotificationFilter.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.notice.service.filter;
+
+import org.jasig.portlet.notice.NotificationCategory;
+import org.jasig.portlet.notice.NotificationEntry;
+
+/**
+ * Encapsulates a single rule that chooses whether a notification stays or goes inside the
+ * {@link FilteringNotificationServiceDecorator};  rules may be combined.
+ *
+ * @since 3.1
+ */
+public interface INotificationFilter {
+
+    /**
+     * Decides whether a {@link NotificationEntry} stays or goes.
+     *
+     * @param category The {@link NotificationCategory} to which the entry belongs
+     * @param entry The {@link NotificationEntry} that may or may not survive
+     * @return <code>true</code> if the entry should survive, otherwise <code>false</code>
+     */
+    boolean doFilter(NotificationCategory category, NotificationEntry entry);
+
+}

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/filter/MaximumPriorityNotificationFilter.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/filter/MaximumPriorityNotificationFilter.java
@@ -54,8 +54,8 @@ import org.slf4j.LoggerFactory;
         // Remember lower number is higher priority...
         final boolean rslt = entry.getPriority() >= maxPriority
                 || entry.getPriority() == NotificationEntry.PRIORITY_UNSPECIFIED;
-        logger.debug("Filtering entry... maxPriority='{}', entry.priority='{}', decision='{}'",
-                maxPriority, entry.getPriority(), rslt);
+        logger.debug("Filtering entry '{}'... maxPriority='{}', entry.priority='{}', decision='{}'",
+                entry.getTitle(), maxPriority, entry.getPriority(), rslt);
         return rslt;
     }
 

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/filter/MaximumPriorityNotificationFilter.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/filter/MaximumPriorityNotificationFilter.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.notice.service.filter;
+
+import org.jasig.portlet.notice.NotificationCategory;
+import org.jasig.portlet.notice.NotificationEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This concrete implementation of {@link INotificationFilter} filters out notices above the
+ * specified priority value.  Remember that higher-priority values are lower numbers -- e.g.
+ * Priority 1 is the highest priority.
+ *
+ * @since 3.1
+ */
+/* package-private */ class MaximumPriorityNotificationFilter implements INotificationFilter {
+
+    private final int maxPriority;
+
+    private Logger logger = LoggerFactory.getLogger(getClass());
+    public MaximumPriorityNotificationFilter(int maxPriority) {
+        if (maxPriority <= 0) {
+            final String msg = "Argument 'maxPriority' must be greater than zero";
+            throw new IllegalArgumentException(msg);
+        }
+
+        this.maxPriority = maxPriority;
+    }
+
+    @Override
+    public boolean doFilter(NotificationCategory category, NotificationEntry entry) {
+        return isNotHigherThanMaximumPriority(entry);
+    }
+
+    private boolean isNotHigherThanMaximumPriority(NotificationEntry entry) {
+        // Remember lower number is higher priority...
+        final boolean rslt = entry.getPriority() >= maxPriority
+                || entry.getPriority() == NotificationEntry.PRIORITY_UNSPECIFIED;
+        logger.debug("Filtering entry... maxPriority='{}', entry.priority='{}', decision='{}'",
+                maxPriority, entry.getPriority(), rslt);
+        return rslt;
+    }
+
+}

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/filter/MinimumPriorityNotificationFilter.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/filter/MinimumPriorityNotificationFilter.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.notice.service.filter;
+
+import org.jasig.portlet.notice.NotificationCategory;
+import org.jasig.portlet.notice.NotificationEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This concrete implementation of {@link INotificationFilter} filters out notices below the
+ * specified priority value, as well as notices that don't have a priority value defined.  Remember
+ * that higher-priority values are lower numbers -- e.g. Priority 1 is the highest priority.
+ *
+ * @since 3.1
+ */
+/* package-private */ class MinimumPriorityNotificationFilter implements INotificationFilter {
+
+    private final int minPriority;
+
+    private Logger logger = LoggerFactory.getLogger(getClass());
+
+    public MinimumPriorityNotificationFilter(int minPriority) {
+        if (minPriority <= 0) {
+            final String msg = "Argument 'minPriority' must be greater than zero";
+            throw new IllegalArgumentException(msg);
+        }
+
+        this.minPriority = minPriority;
+    }
+
+    @Override
+    public boolean doFilter(NotificationCategory category, NotificationEntry entry) {
+        return isAtLeastMinimumPriority(entry);
+    }
+
+    private boolean isAtLeastMinimumPriority(NotificationEntry entry) {
+        // Remember lower number is higher priority...
+        final boolean rslt = entry.getPriority() <= minPriority
+                && entry.getPriority() != NotificationEntry.PRIORITY_UNSPECIFIED;
+        logger.debug("Filtering entry... minPriority='{}', entry.priority='{}', decision='{}'",
+                minPriority, entry.getPriority(), rslt);
+        return rslt;
+    }
+
+}

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/filter/MinimumPriorityNotificationFilter.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/filter/MinimumPriorityNotificationFilter.java
@@ -55,8 +55,8 @@ import org.slf4j.LoggerFactory;
         // Remember lower number is higher priority...
         final boolean rslt = entry.getPriority() <= minPriority
                 && entry.getPriority() != NotificationEntry.PRIORITY_UNSPECIFIED;
-        logger.debug("Filtering entry... minPriority='{}', entry.priority='{}', decision='{}'",
-                minPriority, entry.getPriority(), rslt);
+        logger.debug("Filtering entry '{}'... minPriority='{}', entry.priority='{}', decision='{}'",
+                entry.getTitle(), minPriority, entry.getPriority(), rslt);
         return rslt;
     }
 

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/filter/RequiredRoleNotificationFilter.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/filter/RequiredRoleNotificationFilter.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.jasig.portlet.notice.service.filter;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jasig.portlet.notice.NotificationCategory;
+import org.jasig.portlet.notice.NotificationEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This concrete implementation of {@link INotificationFilter} filters notices based on role.  The
+ * way it works is perhaps more complicated than other filters:  it must be defined with portlet
+ * preferences (like other filters), but it will only exclude notices that have a fully-qualified
+ * <code>requiredRole</code> attribute defined.  (See <code>REQUIRED_ROLE_ATTRIBUTE_NAME</code>
+ * below.)
+ *
+ * @since 3.1
+ */
+/* package-private */ class RequiredRoleNotificationFilter implements INotificationFilter {
+
+    public static final String REQUIRED_ROLE_ATTRIBUTE_NAME =
+            RequiredRoleNotificationFilter.class.getName() + ".requiredRole";
+
+    private final Set<String> userRolesLowerCase;
+
+    private Logger logger = LoggerFactory.getLogger(getClass());
+
+    public RequiredRoleNotificationFilter(Set<String> userRoles) {
+        this.userRolesLowerCase = userRoles.stream()
+                .map(role -> role.toLowerCase())
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean doFilter(NotificationCategory category, NotificationEntry entry) {
+
+
+        final List<String> requiredRoleValues = entry.getAttributesMap().get(REQUIRED_ROLE_ATTRIBUTE_NAME);
+        if (requiredRoleValues == null || requiredRoleValues.size() == 0) {
+            // The entry doesn't specify any roles, so we don't need any checking
+            return true;
+        } else {
+            // We're interested in whether there is intersection between the 2 collections
+            boolean rslt = requiredRoleValues.stream()
+                    .anyMatch(role -> userRolesLowerCase.contains(role.toLowerCase()));
+            logger.debug("Filtering entry '{}'... requiredRoleValues='{}', userRolesLowerCase='{}', decision='{}'",
+                    entry.getTitle(), requiredRoleValues, userRolesLowerCase, rslt);
+            return rslt;
+        }
+
+
+    }
+
+}

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaNotificationService.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jpa/JpaNotificationService.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Service;
 
 /**
  * Implementation of {@code INotificationService} backed by a Spring-/JPA-managed

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/util/PortletXmlRoleService.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/util/PortletXmlRoleService.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.notice.util;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.ServletContext;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.ServletContextAware;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+/**
+ * This class attempts to read the portlet.xml file to determine what groups should be available to
+ * evaluate against. Each group is a <security-role-ref> element in the portlet.xml
+ *
+ * @since 3.1
+ */
+@Service
+public class PortletXmlRoleService implements ServletContextAware {
+
+    private static final String PORTLET_XML_PATH = "/WEB-INF/portlet.xml";
+
+    private Set<String> roles = Collections.emptySet();
+    private ServletContext context;
+
+    private Logger logger = LoggerFactory.getLogger(getClass());
+
+    public void setServletContext(ServletContext context) {
+        this.context = context;
+    }
+
+    @PostConstruct
+    public void init() {
+        final Document doc = parseXml();
+
+        if (doc != null) {
+            String roleNameCandidate;
+            Set<String> set = new HashSet<>();
+
+            // Find all the <security-role-ref> elements in the file
+            final NodeList roleSections = doc.getElementsByTagName("security-role-ref");
+            for (int i = 0; i < roleSections.getLength(); i++) {
+                // for each <security-role-ref>, get the child nodes
+                if (roleSections.item(i).hasChildNodes()) {
+                    final NodeList roleNames = roleSections.item(i).getChildNodes();
+                    for (int j = 0; j < roleNames.getLength(); j++) {
+                        // go through the child nodes of each <security-role-ref> to find the <role-name> node
+                        if (roleNames.item(j).getNodeName().equalsIgnoreCase("role-name")) {
+                            // copy the <role-name> to the roles list if it's not there already
+                            roleNameCandidate = roleNames.item(j).getTextContent();
+                            set.add(roleNameCandidate);
+                        }
+                    }
+                }
+            }
+
+            roles = Collections.unmodifiableSet(set);
+            logger.info("Successfully instantiated and found roles: {}", roles);
+        } else {
+            logger.error("Error parsing the file: {}. See other messages for trace.", PORTLET_XML_PATH);
+        }
+    }
+
+    public Set<String> getAllRoles() {
+        return roles;
+    }
+
+    private Document parseXml() {
+
+        Document rslt = null;
+
+        try {
+            final URL portletXmlUrl = context.getResource(PORTLET_XML_PATH);
+            final DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            final InputSource xmlInp = new InputSource(portletXmlUrl.openStream());
+            final DocumentBuilder dbl = dbf.newDocumentBuilder();
+            rslt = dbl.parse(xmlInp);
+            logger.debug("Finished parsing ", PORTLET_XML_PATH);
+        } catch (Exception e) {
+            logger.error("Failed to parse the specified document: {}", PORTLET_XML_PATH, e);
+        }
+
+        return rslt;
+
+    }
+
+}

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/context/applicationContext.xml
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/context/applicationContext.xml
@@ -130,15 +130,23 @@
      +-->
 
     <!-- ClassLoader:  Use 'ClassLoaderResourceNotificationService.locations' preference to specify location of data files -->
-    <bean id="classLoaderResourceNotificationService" class="org.jasig.portlet.notice.service.classloader.ClassLoaderResourceNotificationService">
-        <property name="name" value="classLoaderResourceNotificationService"/>
+    <bean id="classLoaderResourceNotificationService" class="org.jasig.portlet.notice.service.filter.FilteringNotificationServiceDecorator">
+        <property name="enclosedNotificationService">
+            <bean class="org.jasig.portlet.notice.service.classloader.ClassLoaderResourceNotificationService">
+                <property name="name" value="classLoaderResourceNotificationService"/>
+            </bean>
+        </property>
     </bean>
     <bean id="ClassLoaderResourceNotificationService.responseCache" class="org.springframework.cache.ehcache.EhCacheFactoryBean"
         p:cacheManager-ref="cacheManager" p:cacheName="ClassLoaderResourceNotificationService.responseCache"/>
 
     <!-- Rome (RSS/Atom):  Use 'RomeNotificationService.urls' preference to specify feeds -->
-    <bean id="romeNotificationService" class="org.jasig.portlet.notice.service.rome.RomeNotificationService">
-        <property name="name" value="romeNoticationService"/>
+    <bean id="romeNotificationService" class="org.jasig.portlet.notice.service.filter.FilteringNotificationServiceDecorator">
+        <property name="enclosedNotificationService">
+            <bean class="org.jasig.portlet.notice.service.rome.RomeNotificationService">
+                <property name="name" value="romeNoticationService"/>
+            </bean>
+        </property>
     </bean>
     <bean id="RomeNotificationService.feedCache" class="org.springframework.cache.ehcache.EhCacheFactoryBean"
         p:cacheManager-ref="cacheManager" p:cacheName="RomeNotificationService.feedCache"/>
@@ -152,25 +160,29 @@
     </bean>
 
     <!-- RESTful JSON:  Use 'RestfulJsonNotificationService.serviceUrls' preference  to specify services -->
-    <bean id="restfulJsonNotificationService" class="org.jasig.portlet.notice.service.rest.RestfulJsonNotificationService">
-        <property name="name" value="restfulJsonNotificationService"/>
-        <!-- For HTTP Basic AuthN -->
-        <property name="usernameEvaluator">
-            <bean class="org.jasig.portlet.notice.service.rest.StringLiteralParameterEvaluator" p:value="${restfulJsonNotificationService.basicauth.username}"/>
+    <bean id="restfulJsonNotificationService" class="org.jasig.portlet.notice.service.filter.FilteringNotificationServiceDecorator">
+        <property name="enclosedNotificationService">
+            <bean class="org.jasig.portlet.notice.service.rest.RestfulJsonNotificationService">
+                <property name="name" value="restfulJsonNotificationService"/>
+                <!-- For HTTP Basic AuthN -->
+                <property name="usernameEvaluator">
+                    <bean class="org.jasig.portlet.notice.service.rest.StringLiteralParameterEvaluator" p:value="${restfulJsonNotificationService.basicauth.username}"/>
+                </property>
+                <property name="passwordEvaluator">
+                    <bean class="org.jasig.portlet.notice.service.rest.StringLiteralParameterEvaluator" p:value="${restfulJsonNotificationService.basicauth.password}"/>
+                </property>
+                <property name="urlParameters">
+                    <util:map>
+                        <entry key="username">
+                            <bean class="org.jasig.portlet.notice.service.rest.UserAttributeParameterEvaluator">
+                                <property name="userAttributeKey" value="user.login.id"/>
+                            </bean>
+                        </entry>
+                    </util:map>
+                </property>
+                <property name="restTemplate" ref="restTemplate"/>
+            </bean>
         </property>
-        <property name="passwordEvaluator">
-            <bean class="org.jasig.portlet.notice.service.rest.StringLiteralParameterEvaluator" p:value="${restfulJsonNotificationService.basicauth.password}"/>
-        </property>
-        <property name="urlParameters">
-            <util:map>
-                <entry key="username">
-                    <bean class="org.jasig.portlet.notice.service.rest.UserAttributeParameterEvaluator">
-                        <property name="userAttributeKey" value="user.login.id"/>
-                    </bean>
-                </entry>
-            </util:map>
-        </property>
-        <property name="restTemplate" ref="restTemplate"/>
     </bean>
     <bean id="httpConnectionManager" class="org.apache.commons.httpclient.MultiThreadedHttpConnectionManager" destroy-method="shutdown">
         <property name="params">
@@ -185,23 +197,43 @@
     </bean>
 
     <!-- PortletEvent:  Use 'NotificationLifecycleController.doEvents' preference to turn on event processing for a portlet definition -->
-    <bean id="portletEventNotificationService" class="org.jasig.portlet.notice.service.event.PortletEventNotificationService">
-        <property name="name" value="portletEventNotificationService"/>
+    <bean id="portletEventNotificationService" class="org.jasig.portlet.notice.service.filter.FilteringNotificationServiceDecorator">
+        <property name="enclosedNotificationService">
+            <bean class="org.jasig.portlet.notice.service.event.PortletEventNotificationService">
+                <property name="name" value="portletEventNotificationService"/>
+            </bean>
+        </property>
     </bean>
     <bean id="PortletEventNotificationService.responseCache" class="org.springframework.cache.ehcache.EhCacheFactoryBean"
         p:cacheManager-ref="cacheManager" p:cacheName="PortletEventNotificationService.responseCache"/>
 
     <!-- JPA -->
-    <bean id="jpaNotificationService" class="org.jasig.portlet.notice.service.jpa.JpaNotificationService">
+    <bean id="jpaNotificationService" class="org.jasig.portlet.notice.service.filter.FilteringNotificationServiceDecorator">
+        <property name="enclosedNotificationService">
+            <ref bean="jpaNotificationServiceInnerBean" />
+        </property>
+    </bean>
+    <!-- This bean must be visible in the application context because other beans depend on it -->
+    <bean id="jpaNotificationServiceInnerBean" class="org.jasig.portlet.notice.service.jpa.JpaNotificationService">
         <property name="name" value="jpaNotificationService"/>
     </bean>
 
     <!-- DEMO -->
-    <bean id="demoNotifications" class="org.jasig.portlet.notice.service.classloader.DemoNotificationService">
-        <property name="name" value="demoNotifications"/>
-        <property name="active" value="true"/>
+    <bean id="demoNotifications" class="org.jasig.portlet.notice.service.filter.FilteringNotificationServiceDecorator">
+        <property name="enclosedNotificationService">
+            <bean class="org.jasig.portlet.notice.service.classloader.DemoNotificationService">
+                <property name="name" value="demoNotifications"/>
+                <property name="active" value="true"/>
+            </bean>
+        </property>
     </bean>
-    <bean id="demoEmergencyAlerts" class="org.jasig.portlet.notice.service.classloader.DemoNotificationService">
+    <bean id="demoEmergencyAlerts" class="org.jasig.portlet.notice.service.filter.FilteringNotificationServiceDecorator">
+        <property name="enclosedNotificationService">
+            <ref bean="demoEmergencyAlertsInnerBean" />
+        </property>
+    </bean>
+    <!-- This bean must be visible in the application context because other beans depend on it -->
+    <bean id="demoEmergencyAlertsInnerBean" class="org.jasig.portlet.notice.service.classloader.DemoNotificationService">
         <property name="name" value="demoEmergencyAlerts"/>
         <property name="active" value="false"/> <!-- The emergency alerts demo can be activated by the EmergencyAlertAdminController. -->
     </bean>
@@ -237,21 +269,24 @@
     </bean>
 
     <!-- SSP notifications -->
+    <bean id="sspNotifications" class="org.jasig.portlet.notice.service.filter.FilteringNotificationServiceDecorator">
+        <property name="enclosedNotificationService">
+            <bean class="org.jasig.portlet.notice.service.ssp.SSPTaskNotificationService">
+                <property name="name" value="sspTaskNotificationService"/>
+                <property name="sspApi" ref="sspApi"/>
+                <property name="personLookup">
+                    <bean class="org.jasig.portlet.notice.service.ssp.SSPSchoolIdPersonLookup">
+                        <property name="sspApi" ref="sspApi"/>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+    </bean>
     <bean class="org.jasig.portlet.notice.service.ssp.SSPApiLocator"/>
     <bean id="StudentSuccessPlanService.schoolIdToPersonIdCache" class="org.springframework.cache.ehcache.EhCacheFactoryBean"
           p:cacheManager-ref="cacheManager" p:cacheName="StudentSuccessPlanService.schoolIdToPersonIdCache"/>
     <bean id="sspApi" class="org.jasig.portlet.notice.service.ssp.SSPApi">
         <property name="restTemplate" ref="restTemplate"/>
-    </bean>
-
-    <bean id="sspNotifications" class="org.jasig.portlet.notice.service.ssp.SSPTaskNotificationService">
-        <property name="name" value="sspTaskNotificationService"/>
-        <property name="sspApi" ref="sspApi"/>
-        <property name="personLookup">
-            <bean class="org.jasig.portlet.notice.service.ssp.SSPSchoolIdPersonLookup">
-                <property name="sspApi" ref="sspApi"/>
-            </bean>
-        </property>
     </bean>
 
 </beans>

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/jsp/alert-admin.jsp
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/jsp/alert-admin.jsp
@@ -20,22 +20,19 @@
 --%>
 <jsp:directive.include file="/WEB-INF/jsp/include.jsp"/>
 
-<div class="fl-widget portlet" role="section">
-    <div class="fl-widget-titlebar titlebar portlet-titlebar" role="sectionhead">
-        <h2 class="title" role="heading"><spring:message code="alertAdmin.title"/></h2>
-        <h3><spring:message code="alertAdmin.text"/> <strong><spring:message code="alertAdmin.${value}"/></strong></h3>
-    </div>
+<div>
+    <h2 class="title" role="heading"><spring:message code="alertAdmin.title"/></h2>
+
+    <p class="lead bg-warning"><spring:message code="alertAdmin.text"/> <strong><spring:message code="alertAdmin.${value}"/></strong></p>
     
-    <div class="toolbar" role="toolbar">
-        <ul>
-            <li style="list-style: none;"><a class="button" href="<portlet:actionURL/>"><spring:message code="alertAdmin.button.${value}"/></a></li>
-        </ul>
-    </div>
+    <ul>
+        <li style="list-style: none;">
+            <a class="btn btn-primary btn-lg" href="<portlet:actionURL/>">
+                <spring:message code="alertAdmin.button.${value}"/>
+            </a>
+        </li>
+    </ul>
     
-    <div class="fl-widget-content content portlet-content" role="main">
-        <div class="portlet-note" role="note">
-            <p><spring:message code="alertAdmin.note"/></p>
-        </div>
-    </div>
+    <p><spring:message code="alertAdmin.note"/></p>
 </div>
 

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/jsp/modal.jsp
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/jsp/modal.jsp
@@ -77,7 +77,7 @@ recommended and more common approach).
     $(function() {
         var container = $("#${n}");
 
-        upmodal_notice.launch(container, {
+        upmodal_notice.launch($, container, {
             invokeNotificationServiceUrl: '${invokeNotificationServiceUrl}',
             invokeActionUrlTemplate: '${invokeActionUrlTemplate}',
             getNotificationsUrl: '<portlet:resourceURL id="GET-NOTIFICATIONS-UNCATEGORIZED"/>'

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -166,6 +166,10 @@
             <preference>
                 <name>FilteringNotificationServiceDecorator.maxPriority</name>
             </preference>
+            <preference>
+                <name>FilteringNotificationServiceDecorator.requiredRole</name>
+                <value>false</value>
+            </preference>
 
             <!-- If true, notifications will piggyback on the portal's JavaScript library (jQuery).
                  Currently as of 2017/09/07, setting this preference to 'true' doesn't work;  there
@@ -175,6 +179,21 @@
                 <value>false</value>
             </preference>
         </portlet-preferences>
+
+        <!-- The role-name (the internal name used by the portlet) should not have spaces in it -->
+        <security-role-ref>
+            <role-name>Faculty</role-name>
+            <role-link>Faculty</role-link>
+        </security-role-ref>
+        <security-role-ref>
+            <role-name>Staff</role-name>
+            <role-link>Staff</role-link>
+        </security-role-ref>
+        <security-role-ref>
+            <role-name>Students</role-name>
+            <role-link>Students</role-link>
+        </security-role-ref>
+
         <supported-processing-event>
             <qname xmlns:x="https://source.jasig.org/schemas/portlet/notification">x:NotificationResult</qname>
         </supported-processing-event>
@@ -260,6 +279,10 @@
             <preference>
                 <name>FilteringNotificationServiceDecorator.maxPriority</name>
             </preference>
+            <preference>
+                <name>FilteringNotificationServiceDecorator.requiredRole</name>
+                <value>false</value>
+            </preference>
 
             <!-- If true, emergency alerts will piggyback on the portal's JavaScript library (jQuery).  The needs
                  of this portlet are very lightweight so we'll default to 'true' in this case. -->
@@ -283,6 +306,21 @@
             </preference>
 
         </portlet-preferences>
+
+        <!-- The role-name (the internal name used by the portlet) should not have spaces in it -->
+        <security-role-ref>
+            <role-name>Faculty</role-name>
+            <role-link>Faculty</role-link>
+        </security-role-ref>
+        <security-role-ref>
+            <role-name>Staff</role-name>
+            <role-link>Staff</role-link>
+        </security-role-ref>
+        <security-role-ref>
+            <role-name>Students</role-name>
+            <role-link>Students</role-link>
+        </security-role-ref>
+
         <supported-processing-event>
             <qname xmlns:x="https://source.jasig.org/schemas/portlet/notification">x:NotificationResult</qname>
         </supported-processing-event>
@@ -423,6 +461,10 @@
             <preference>
                 <name>FilteringNotificationServiceDecorator.maxPriority</name>
             </preference>
+            <preference>
+                <name>FilteringNotificationServiceDecorator.requiredRole</name>
+                <value>false</value>
+            </preference>
 
             <!-- If true, notification icon will piggyback on the portal's JavaScript library (jQuery).  The needs
                  of this portlet are very lightweight so we'll default to 'true' in this case. -->
@@ -458,6 +500,21 @@
             </preference>
 
         </portlet-preferences>
+
+        <!-- The role-name (the internal name used by the portlet) should not have spaces in it -->
+        <security-role-ref>
+            <role-name>Faculty</role-name>
+            <role-link>Faculty</role-link>
+        </security-role-ref>
+        <security-role-ref>
+            <role-name>Staff</role-name>
+            <role-link>Staff</role-link>
+        </security-role-ref>
+        <security-role-ref>
+            <role-name>Students</role-name>
+            <role-link>Students</role-link>
+        </security-role-ref>
+
         <supported-processing-event>
             <qname xmlns:x="https://source.jasig.org/schemas/portlet/notification">x:NotificationResult</qname>
         </supported-processing-event>

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/portlet.xml
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/portlet.xml
@@ -158,9 +158,18 @@
                 <value>ASCENDING</value>
             </preference>
 
+            <!-- The following preferences control filtering:  the ability to
+                 exclude notices based on priority, category, etc. -->
+            <preference>
+                <name>FilteringNotificationServiceDecorator.minPriority</name>
+            </preference>
+            <preference>
+                <name>FilteringNotificationServiceDecorator.maxPriority</name>
+            </preference>
+
             <!-- If true, notifications will piggyback on the portal's JavaScript library (jQuery).
-                 The needs of this portlet are very lightweight so we should default to 'true' in
-                 this case but that's pending broader consensus. -->
+                 Currently as of 2017/09/07, setting this preference to 'true' doesn't work;  there
+                 appears to be a library incompatibility. -->
             <preference>
                 <name>usePortalJsLibs</name>
                 <value>false</value>
@@ -241,6 +250,15 @@
                  is empty -->
             <preference>
                 <name>NotificationLifecycleController.invokeRedirectPort</name>
+            </preference>
+
+            <!-- The following preferences control filtering:  the ability to
+                 exclude notices based on priority, category, etc. -->
+            <preference>
+                <name>FilteringNotificationServiceDecorator.minPriority</name>
+            </preference>
+            <preference>
+                <name>FilteringNotificationServiceDecorator.maxPriority</name>
             </preference>
 
             <!-- If true, emergency alerts will piggyback on the portal's JavaScript library (jQuery).  The needs
@@ -395,6 +413,15 @@
                  is empty -->
             <preference>
                 <name>NotificationLifecycleController.invokeRedirectPort</name>
+            </preference>
+
+            <!-- The following preferences control filtering:  the ability to
+                 exclude notices based on priority, category, etc. -->
+            <preference>
+                <name>FilteringNotificationServiceDecorator.minPriority</name>
+            </preference>
+            <preference>
+                <name>FilteringNotificationServiceDecorator.maxPriority</name>
             </preference>
 
             <!-- If true, notification icon will piggyback on the portal's JavaScript library (jQuery).  The needs

--- a/notification-portlet-webapp/src/main/webapp/scripts/modal-notice.js
+++ b/notification-portlet-webapp/src/main/webapp/scripts/modal-notice.js
@@ -19,146 +19,146 @@
 /*
  * This file leverages Modal Bootstrap to display a single notice, like an Term of Service
  */
-
 var upmodal_notice = upmodal_notice || {};
 
-if (!upmodal_notice.init) {
-  upmodal_notice.init = true;
+(function() {
 
-  (function() { // necessary?
+    if (!upmodal_notice.init) {
+        upmodal_notice.init = true;
 
-    var defaults = {
-      selectors: {
-        content: '.np-content',
-        title: '.np-title',
-        form: '.np-action-form',
-        body: '.np-body',
-        link: '.np-link',
-        actions: '.np-actions',
-        actionTemplate: '.np-action-template',
-        closeButton: '.np-close'
-      }
-    };
+        var defaults = {
+            selectors: {
+                content: '.np-content',
+                title: '.np-title',
+                form: '.np-action-form',
+                body: '.np-body',
+                link: '.np-link',
+                actions: '.np-actions',
+                actionTemplate: '.np-action-template',
+                closeButton: '.np-close'
+            }
+        };
 
-    upmodal_notice.launch = function ($, container, options) {
-      var settings = $.extend({}, defaults, options);
+        upmodal_notice.launch = function($, container, options) {
+            var settings = $.extend({}, defaults, options);
 
-      // First 'prime-the-pump' with an ActionURL
-      var initNotices = function(settings, callback) {
-        $.ajax({
-          type: 'POST',
-          url: settings.invokeNotificationServiceUrl,
-          async: false,
-          success: function() {
-            fetchNotices(settings, callback);
-          },
-          error: console.error
-        });
-      }
-
-      // Then fetch the notifications with a ResourceURL
-      var fetchNotices = function(settings, callback) {
-        $.ajax({
-          url: settings.getNotificationsUrl,
-          type: 'POST',
-          dataType: 'json',
-          success: function (data) {
-            var feed = data.feed;
-            callback(feed);
-          },
-          error: console.error
-        });
-      }
-
-      var handleAction = function() {
-        var actionButton = $(this);
-        var formElement = container.find(settings.selectors.form);
-        $.post(actionButton.attr('data-url'), formElement.serialize(), console.log);
-        // Any action closes the modal window
-        container.modal('hide');
-      }
-
-      var resetDialog = function() {
-        container.off('hidden.bs.modal'); // Clear previous event handler(s)
-        container.find(settings.selectors.closeButton).hide();
-        container.find(settings.selectors.actions).find('.np-action').remove();
-      }
-
-      var drawActions = function(alert) {
-        var actionsContainer = container.find(settings.selectors.actions);
-        var availableActions = alert.availableActions;
-        var actionTemplate = actionsContainer.find(settings.selectors.actionTemplate);
-
-        if (availableActions && availableActions.length > 0) {
-          // Draw actions if we have them...
-          availableActions.forEach(function (action, index) {
-            var actionUrl = settings
-              .invokeActionUrlTemplate
-              .replace('NOTIFICATIONID', alert.id)
-              .replace('ACTIONID', action.id);
-
-            var actionElement = actionTemplate.clone();
-            actionElement.removeClass('np-action-template');
-            actionElement.toggleClass('hidden');
-            actionElement.addClass('np-action');
-
-            if (index === 0) {
-              // Only the first button is btn-primary
-              actionElement.find('a').addClass('btn-primary');
+            // First 'prime-the-pump' with an ActionURL
+            var initNotices = function(settings, callback) {
+                $.ajax({
+                    type: 'POST',
+                    url: settings.invokeNotificationServiceUrl,
+                    async: false,
+                    success: function() {
+                        fetchNotices(settings, callback);
+                    },
+                    error: console.error
+                });
             }
 
-            actionElement.find('a').attr('data-url', actionUrl).html(action.label).click(handleAction);
-            actionElement.appendTo(actionsContainer);
-          })
-        } else {
-          // Or offer a close (x) button if we don't...
-          container.find(settings.selectors.closeButton).show();
+            // Then fetch the notifications with a ResourceURL
+            var fetchNotices = function(settings, callback) {
+                $.ajax({
+                    url: settings.getNotificationsUrl,
+                    type: 'POST',
+                    dataType: 'json',
+                    success: function(data) {
+                        var feed = data.feed;
+                        callback(feed);
+                    },
+                    error: console.error
+                });
+            }
+
+            var handleAction = function() {
+                var actionButton = $(this);
+                var formElement = container.find(settings.selectors.form);
+                $.post(actionButton.attr('data-url'), formElement.serialize(), console.log);
+                // Any action closes the modal window
+                container.modal('hide');
+            }
+
+            var resetDialog = function() {
+                container.off('hidden.bs.modal'); // Clear previous event handler(s)
+                container.find(settings.selectors.closeButton).hide();
+                container.find(settings.selectors.actions).find('.np-action').remove();
+            }
+
+            var drawActions = function(alert) {
+                var actionsContainer = container.find(settings.selectors.actions);
+                var availableActions = alert.availableActions;
+                var actionTemplate = actionsContainer.find(settings.selectors.actionTemplate);
+
+                if (availableActions && availableActions.length > 0) {
+                    // Draw actions if we have them...
+                    availableActions.forEach(function(action, index) {
+                        var actionUrl = settings
+                            .invokeActionUrlTemplate
+                            .replace('NOTIFICATIONID', alert.id)
+                            .replace('ACTIONID', action.id);
+
+                        var actionElement = actionTemplate.clone();
+                        actionElement.removeClass('np-action-template');
+                        actionElement.toggleClass('hidden');
+                        actionElement.addClass('np-action');
+
+                        if (index === 0) {
+                            // Only the first button is btn-primary
+                            actionElement.find('a').addClass('btn-primary');
+                        }
+
+                        actionElement.find('a').attr('data-url', actionUrl).html(action.label)
+                                .click(handleAction);
+                        actionElement.appendTo(actionsContainer);
+                    })
+                } else {
+                    // Or offer a close (x) button if we don't...
+                    container.find(settings.selectors.closeButton).show();
+                }
+            }
+
+            var drawAlert = function(alert) {
+                var content = container.find(settings.selectors.content);
+                // Insert context
+                content.find(settings.selectors.title).html(alert.title);
+
+                if (alert.body) {
+                    content.find(settings.selectors.body).html(alert.body);
+                }
+
+                if (alert.url) {
+                    var linkText = alert.linkText || alert.url;
+                    content.find(settings.selectors.link).attr('href', alert.url).html(linkText);
+                }
+
+                // Add the actions
+                drawActions(alert);
+            }
+
+            var showNextNotice = function(feed, index) {
+                var alert = feed[index];
+                resetDialog();
+                drawAlert(alert);
+
+                if (feed.length > index + 1) {
+                    // There are more notices after this one...
+                    container.on('hidden.bs.modal', function() {
+                        showNextNotice(feed, index + 1);
+                    });
+                }
+                container.modal("show");
+            }
+
+            var showEachNoticeInTurn = function(feed) {
+                // Do we have any notices to show?
+                if (feed && feed.length !== 0) {
+                    showNextNotice(feed, 0);
+                }
+            }
+
+            // Invoke notifications
+            initNotices(settings, showEachNoticeInTurn);
         }
-      }
 
-      var drawAlert = function(alert) {
-        var content = container.find(settings.selectors.content);
-        // Insert context
-        content.find(settings.selectors.title).html(alert.title);
-
-        if (alert.body) {
-          content.find(settings.selectors.body).html(alert.body);
-        }
-
-        if (alert.url) {
-          var linkText = alert.linkText || alert.url;
-          content.find(settings.selectors.link).attr('href', alert.url).html(linkText);
-        }
-
-        // Add the actions
-        drawActions(alert);
-      }
-
-      var showNextNotice = function(feed, index) {
-        var alert = feed[index];
-        resetDialog();
-        drawAlert(alert);
-
-        if (feed.length > index + 1) {
-          // There are more notices after this one...
-          container.on('hidden.bs.modal', function() {
-            showNextNotice(feed, index + 1);
-          });
-        }
-        container.modal("show");
-      }
-
-      var showEachNoticeInTurn = function(feed) {
-        // Do we have any notices to show?
-        if (feed && feed.length !== 0) {
-          showNextNotice(feed, 0);
-        }
-      }
-
-      // Invoke notifications
-      initNotices(settings, showEachNoticeInTurn);
     }
 
-  })();
-
-}
+})();

--- a/notification-portlet-webapp/src/main/webapp/scripts/modal-notice.js
+++ b/notification-portlet-webapp/src/main/webapp/scripts/modal-notice.js
@@ -25,7 +25,8 @@ var upmodal_notice = upmodal_notice || {};
 if (!upmodal_notice.init) {
   upmodal_notice.init = true;
 
-  (function($) {
+  (function() { // necessary?
+
     var defaults = {
       selectors: {
         content: '.np-content',
@@ -39,35 +40,35 @@ if (!upmodal_notice.init) {
       }
     };
 
-    // First 'prime-the-pump' with an ActionURL
-    var initNotices = function(settings, callback) {
-      $.ajax({
-        type: 'POST',
-        url: settings.invokeNotificationServiceUrl,
-        async: false,
-        success: function() {
-          fetchNotices(settings, callback);
-        },
-        error: console.error
-      });
-    }
-
-    // Then fetch the notifications with a ResourceURL
-    var fetchNotices = function(settings, callback) {
-      $.ajax({
-        url: settings.getNotificationsUrl,
-        type: 'POST',
-        dataType: 'json',
-        success: function (data) {
-          var feed = data.feed;
-          callback(feed);
-        },
-        error: console.error
-      });
-    }
-
-    upmodal_notice.launch = function (container, options) {
+    upmodal_notice.launch = function ($, container, options) {
       var settings = $.extend({}, defaults, options);
+
+      // First 'prime-the-pump' with an ActionURL
+      var initNotices = function(settings, callback) {
+        $.ajax({
+          type: 'POST',
+          url: settings.invokeNotificationServiceUrl,
+          async: false,
+          success: function() {
+            fetchNotices(settings, callback);
+          },
+          error: console.error
+        });
+      }
+
+      // Then fetch the notifications with a ResourceURL
+      var fetchNotices = function(settings, callback) {
+        $.ajax({
+          url: settings.getNotificationsUrl,
+          type: 'POST',
+          dataType: 'json',
+          success: function (data) {
+            var feed = data.feed;
+            callback(feed);
+          },
+          error: console.error
+        });
+      }
 
       var handleAction = function() {
         var actionButton = $(this);
@@ -157,5 +158,7 @@ if (!upmodal_notice.init) {
       // Invoke notifications
       initNotices(settings, showEachNoticeInTurn);
     }
-  })(up.jQuery);
+
+  })();
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -403,8 +403,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
…can filter (exclude some) notifications based on preferences configured in the portlet definition

https://issues.jasig.org/browse/NOTIFPLT-87

Examples...

  - Exclude all notices with less than top priority (priority=1)
  - Exclude all notices with greater than bottom priority (priority=5)
  - Exclude all notices that are not in the 'Library' category

This feature will allow admins to 'route' notifications from a common source to different display strategies ('normal', modal, emergency alerts, etc).
