### PR TITLE
build(maven): allow maven release plugin to push release changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,7 +318,6 @@
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <localCheckout>true</localCheckout>
                         <tagNameFormat>NotificationPortlet-@{project.version}</tagNameFormat>
-                        <pushChanges>false</pushChanges>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
This speeds up the release process by removing the push branch and push tag steps.
While also reducing the chance that a release could be cut but accidentally never be tagged and pushed.