### PR TITLE
Fix: modal on firefox

### DIFF
--- a/notification-portlet-webcomponents/notification-modal/package-lock.json
+++ b/notification-portlet-webcomponents/notification-modal/package-lock.json
@@ -845,9 +845,9 @@
       }
     },
     "@uportal/open-id-connect": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@uportal/open-id-connect/-/open-id-connect-1.5.0.tgz",
-      "integrity": "sha512-1iJ+S4GufgPs+eNKx2F8vvoX8twB/J1gMv2g0g5FlZA/faoE9QXdOvQmISVcgkFzQmcQVWFcJW9P7UQep/aPiw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@uportal/open-id-connect/-/open-id-connect-1.6.0.tgz",
+      "integrity": "sha512-qRleET88T2xBN9mk1I7v5geVigNqpTWahpw58Oca3iB9r1vV33Yp0si0lCj+Vjh53hyNB0tQ+s6o9FsD2Ycgxg==",
       "requires": {
         "axios": "^0.18.0",
         "jwt-decode": "^2.2.0",
@@ -855,9 +855,9 @@
       }
     },
     "@vue/babel-preset-app": {
-      "version": "3.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-3.0.0-rc.10.tgz",
-      "integrity": "sha1-2kbYiGABHcpglUwMhpK9xovlUqY=",
+      "version": "3.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@vue/babel-preset-app/-/babel-preset-app-3.0.0-rc.12.tgz",
+      "integrity": "sha512-gIE1MFEY4YMlZ5khqn0Zui6YQoTfwshj7VvknJnTzwsiBV4DCWbpRJrHwZoglKLANB8Qvom1E6UlQ6LgdaE3Cw==",
       "dev": true,
       "requires": {
         "@babel/plugin-proposal-class-properties": "7.0.0-beta.47",
@@ -873,46 +873,45 @@
       }
     },
     "@vue/cli-overlay": {
-      "version": "3.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@vue/cli-overlay/-/cli-overlay-3.0.0-rc.10.tgz",
-      "integrity": "sha1-1/yG4bGvwbeuUodcOIpVMsDBBQU=",
+      "version": "3.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@vue/cli-overlay/-/cli-overlay-3.0.0-rc.12.tgz",
+      "integrity": "sha512-1Q8UsN6E9nXACReUxWTYT9Dn5gAOSSLMYnFhfTOm5l705J0vQIkDBWzJ01MzHdUB9zg+lOgrE2AF+Bvw9qKtVA==",
       "dev": true
     },
     "@vue/cli-plugin-babel": {
-      "version": "3.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-babel/-/cli-plugin-babel-3.0.0-rc.10.tgz",
-      "integrity": "sha1-YWrAlYknEGNT035h3vPPWTxeSm8=",
+      "version": "3.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-babel/-/cli-plugin-babel-3.0.0-rc.12.tgz",
+      "integrity": "sha512-G4BaI5Og5IMBvffhYrmSEnmz17t/+420S2HZvP0T9x2nK4tJQaffxYcPMVCehll6pUJ6dvoRsYRfPzUX2Fbbtg==",
       "dev": true,
       "requires": {
         "@babel/core": "7.0.0-beta.47",
-        "@vue/babel-preset-app": "^3.0.0-rc.10",
+        "@vue/babel-preset-app": "^3.0.0-rc.12",
         "babel-loader": "^8.0.0-0"
       }
     },
     "@vue/cli-plugin-eslint": {
-      "version": "3.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-eslint/-/cli-plugin-eslint-3.0.0-rc.10.tgz",
-      "integrity": "sha1-yjA0/ZzoKIGSVheM7CSdNhqUTMg=",
+      "version": "3.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@vue/cli-plugin-eslint/-/cli-plugin-eslint-3.0.0-rc.12.tgz",
+      "integrity": "sha512-X5Of/31CCDD9AQ68Vb5XVsKZFg4w0an7764mVBvgGRhALmCcHL1Kasr2sc0oXMxJDEp868tFA2bvxrYBmRsDEw==",
       "dev": true,
       "requires": {
-        "@vue/cli-shared-utils": "^3.0.0-rc.10",
+        "@vue/cli-shared-utils": "^3.0.0-rc.12",
         "babel-eslint": "^8.2.5",
         "eslint": "^4.19.1",
         "eslint-loader": "^2.0.0",
-        "eslint-plugin-vue": "^4.5.0",
-        "launch-editor": "^2.2.1"
+        "eslint-plugin-vue": "^4.5.0"
       }
     },
     "@vue/cli-service": {
-      "version": "3.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@vue/cli-service/-/cli-service-3.0.0-rc.10.tgz",
-      "integrity": "sha1-wb94PzXcyJfP3VvIUmj5hSjd6lE=",
+      "version": "3.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@vue/cli-service/-/cli-service-3.0.0-rc.12.tgz",
+      "integrity": "sha512-B7mcu5l6fIq6M9oEWa1+fmpLiGiAQ4TP3wefzI20PmzQaE1nXLRMvy+KoalGhmv71ccp7ArM0BF5bLs8tYuBTw==",
       "dev": true,
       "requires": {
         "@intervolga/optimize-cssnano-plugin": "^1.0.5",
-        "@vue/cli-overlay": "^3.0.0-rc.10",
-        "@vue/cli-shared-utils": "^3.0.0-rc.10",
-        "@vue/preload-webpack-plugin": "^1.0.0",
+        "@vue/cli-overlay": "^3.0.0-rc.12",
+        "@vue/cli-shared-utils": "^3.0.0-rc.12",
+        "@vue/preload-webpack-plugin": "^1.1.0",
         "@vue/web-component-wrapper": "^1.2.0",
         "acorn": "^5.7.1",
         "address": "^1.0.3",
@@ -945,12 +944,12 @@
         "semver": "^5.5.0",
         "slash": "^2.0.0",
         "source-map-url": "^0.4.0",
+        "ssri": "^6.0.0",
         "string.prototype.padend": "^3.0.0",
         "thread-loader": "^1.1.5",
         "uglifyjs-webpack-plugin": "^1.2.7",
         "url-loader": "^1.0.1",
-        "vue-loader": "^15.2.4",
-        "vue-template-compiler": "^2.5.16",
+        "vue-loader": "^15.3.0",
         "webpack": "^4.15.1",
         "webpack-bundle-analyzer": "^2.13.1",
         "webpack-chain": "^4.8.0",
@@ -1014,14 +1013,15 @@
       }
     },
     "@vue/cli-shared-utils": {
-      "version": "3.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-3.0.0-rc.10.tgz",
-      "integrity": "sha1-nhy65Kmfis0HiLIpyGrPAnelrxw=",
+      "version": "3.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-3.0.0-rc.12.tgz",
+      "integrity": "sha512-kstleuH+rAx6igOV1Jj86Qfk68N4tBNoBY7lohsE4oeYTNaVOl6ydHg0epX9mB3XM977vDo9Y8oQmH1Y6QnfFw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",
         "execa": "^0.10.0",
         "joi": "^13.0.0",
+        "launch-editor": "^2.2.1",
         "node-ipc": "^9.1.1",
         "opn": "^5.3.0",
         "ora": "^2.1.0",
@@ -1072,9 +1072,9 @@
       }
     },
     "@vue/component-compiler-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.1.0.tgz",
-      "integrity": "sha512-CEAYcnQsO42aKnIOQdzTLonpa936Tl8sJSHciMzNgy/p+tvqycjwK9Knm6vUrkVE/fWV2NVcNWI+fmvUPxkxWQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-2.1.2.tgz",
+      "integrity": "sha512-ISkl1xQhYgPwxlhq9KPUgjWurTS4atdvMhc0cpIPbXdyCDEKkDRS4wsDM6jNtoMSVKoDLfOiCPP4TZTwAu0uEQ==",
       "dev": true,
       "requires": {
         "consolidate": "^0.15.1",
@@ -1083,7 +1083,7 @@
         "merge-source-map": "^1.1.0",
         "postcss": "^6.0.20",
         "postcss-selector-parser": "^3.1.1",
-        "prettier": "^1.13.7",
+        "prettier": "1.13.7",
         "source-map": "^0.5.6",
         "vue-template-es2015-compiler": "^1.6.0"
       },
@@ -1150,9 +1150,9 @@
       }
     },
     "@vue/eslint-config-prettier": {
-      "version": "3.0.0-rc.10",
-      "resolved": "https://registry.npmjs.org/@vue/eslint-config-prettier/-/eslint-config-prettier-3.0.0-rc.10.tgz",
-      "integrity": "sha1-uhgocNDUzjw5LsoO20OV8lz5xp4=",
+      "version": "3.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@vue/eslint-config-prettier/-/eslint-config-prettier-3.0.0-rc.12.tgz",
+      "integrity": "sha512-jQiqkjnlp1Y3Pb8UmFUWM3HtWZOU1WL98M5pwEV+r7UEfbhmfc5UaCB73nApeoIabQajwk7187pgZm8ZxFtn5g==",
       "dev": true,
       "requires": {
         "eslint-config-prettier": "^2.9.0",
@@ -1161,9 +1161,9 @@
       }
     },
     "@vue/preload-webpack-plugin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@vue/preload-webpack-plugin/-/preload-webpack-plugin-1.0.0.tgz",
-      "integrity": "sha512-vnoSuMyoaXEUMvEzfxtASB3EKe5jmdlJoMIP2yABWZ+QJnGtsFBZTNVmVVBuNbar+3zWh/b/ssquw05w6WIFJQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vue/preload-webpack-plugin/-/preload-webpack-plugin-1.1.0.tgz",
+      "integrity": "sha512-rcn2KhSHESBFMPj5vc5X2pI9bcBNQQixvJXhD5gZ4rN2iym/uH2qfDSQfUS5+qwiz0a85TCkeUs6w6jxFDudbw==",
       "dev": true
     },
     "@vue/web-component-wrapper": {
@@ -1987,10 +1987,13 @@
       "dev": true
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
     },
     "asn1.js": {
       "version": "4.10.1",
@@ -2146,9 +2149,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
     "axios": {
@@ -2615,23 +2618,6 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
-    "boom": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        }
-      }
-    },
     "bootstrap": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.3.tgz",
@@ -2770,9 +2756,9 @@
       }
     },
     "buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "buffer-indexof": {
@@ -2824,6 +2810,17 @@
         "ssri": "^5.2.4",
         "unique-filename": "^1.1.0",
         "y18n": "^4.0.0"
+      },
+      "dependencies": {
+        "ssri": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
+          "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.1"
+          }
+        }
       }
     },
     "cache-base": {
@@ -2936,9 +2933,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000865",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000865.tgz",
-      "integrity": "sha512-vs79o1mOSKRGv/1pSkp4EXgl4ZviWeYReXw60XfacPU64uQWZwJT6vZNmxRF9O+6zu71sJwMxLK5JXxbzuVrLw==",
+      "version": "1.0.30000874",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000874.tgz",
+      "integrity": "sha512-29nr1EPiHwrJTAHHsEmTt2h+55L8j2GNFdAcYPlRy2NX6iFz7ZZiepVI7kP/QqlnHLq3KvfWpbmGa0d063U09w==",
       "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {
@@ -3385,9 +3382,9 @@
       "dev": true
     },
     "color-string": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.2.tgz",
-      "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
       "dev": true,
       "requires": {
         "color-name": "^1.0.0",
@@ -3631,9 +3628,9 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.5.tgz",
-      "integrity": "sha512-94j37OtvxS5w7qr7Ta6dt67tWdnOxigBVN4VnSxNXFez9o18PGQ0D33SchKP17r9LAcWVTYV72G6vDayAUBFIg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
+      "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
       "dev": true,
       "requires": {
         "is-directory": "^0.3.1",
@@ -3689,15 +3686,6 @@
         "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
-      }
-    },
-    "cryptiles": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
-      "requires": {
-        "boom": "2.x.x"
       }
     },
     "crypto-browserify": {
@@ -4598,9 +4586,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.52",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.52.tgz",
-      "integrity": "sha1-0tnxJwuko7lnuDHEDvcftNmrXOA=",
+      "version": "1.3.56",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.56.tgz",
+      "integrity": "sha512-h4FnvXgyfJaA1egXqCwfpecFu1k6U4sPqwvCeux2yEWbu+Avlsa9i07iB5M+M1M2iyfEUnuQDWYCkPCkfO5cpg==",
       "dev": true
     },
     "elegant-spinner": {
@@ -4610,9 +4598,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -5681,9 +5669,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
-      "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.2.tgz",
+      "integrity": "sha512-kssLorP/9acIdpQ2udQVTiCS5LQmdEz9mvdIfDcl1gYX2tPKFADHSyFdvJS040XdFsPzemWtgI3q8mFVCxtX8A==",
       "requires": {
         "debug": "^3.1.0"
       }
@@ -6671,26 +6659,6 @@
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "hawk": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
-      "requires": {
-        "boom": "2.x.x",
-        "cryptiles": "2.x.x",
-        "hoek": "2.x.x",
-        "sntp": "1.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        }
       }
     },
     "he": {
@@ -7934,15 +7902,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
       "dev": true
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -9429,9 +9388,9 @@
       "dev": true
     },
     "node-gyp": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.7.0.tgz",
-      "integrity": "sha512-qDQE/Ft9xXP6zphwx4sD0t+VhwV7yFaloMpfbL2QnnDZcyaiakWlLdtFGGQfTAwpFHdpbRhRxVhIHN1OKAjgbg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+      "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
       "dev": true,
       "requires": {
         "fstream": "^1.0.0",
@@ -9441,115 +9400,13 @@
         "nopt": "2 || 3",
         "npmlog": "0 || 1 || 2 || 3 || 4",
         "osenv": "0",
-        "request": ">=2.9.0 <2.82.0",
+        "request": "^2.87.0",
         "rimraf": "2",
         "semver": "~5.3.0",
         "tar": "^2.0.0",
         "which": "1"
       },
       "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "^4.6.0",
-            "json-stable-stringify": "^1.0.1"
-          }
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true,
-          "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
-          }
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "^0.2.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
-          }
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
-          }
-        },
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -9618,9 +9475,9 @@
       }
     },
     "node-sass": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.2.tgz",
-      "integrity": "sha512-LdxoJLZutx0aQXHtWIYwJKMj+9pTjneTcLWJgzf2XbGu0q5pRNqW5QvFCEdm3mc5rJOdru/mzln5d0EZLacf6g==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.3.tgz",
+      "integrity": "sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",
@@ -9636,7 +9493,7 @@
         "meow": "^3.7.0",
         "mkdirp": "^0.5.1",
         "nan": "^2.10.0",
-        "node-gyp": "^3.3.1",
+        "node-gyp": "^3.8.0",
         "npmlog": "^4.0.0",
         "request": "2.87.0",
         "sass-graph": "^2.2.4",
@@ -10024,12 +9881,12 @@
       }
     },
     "original": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/original/-/original-1.0.1.tgz",
-      "integrity": "sha512-IEvtB5vM5ULvwnqMxWBLxkS13JIEXbakizMSo3yoPNPCIWzg8TG3Usn/UhXoZFM/m+FuEA20KdzPSFq/0rS+UA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
       "dev": true,
       "requires": {
-        "url-parse": "~1.4.0"
+        "url-parse": "^1.4.3"
       }
     },
     "os-browserify": {
@@ -10244,9 +10101,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "path-to-regexp": {
@@ -10327,14 +10184,14 @@
       "dev": true
     },
     "popper.js": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz",
-      "integrity": "sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU="
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.4.tgz",
+      "integrity": "sha1-juwdj/AqWjoVLdQ0FKFce3n9abY="
     },
     "portfinder": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
-      "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.16.tgz",
+      "integrity": "sha512-icBXCFQxzlK2PMepOM0QeEdPPFSLAaXXeuKOv5AClJlMy1oVCBrkDGJ12IZYesI/BF8mpeVco3vRCmgeBb4+hw==",
       "dev": true,
       "requires": {
         "async": "^1.5.2",
@@ -12403,9 +12260,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.0.tgz",
-      "integrity": "sha512-KtQ2EGaUwf2EyDfp1fxyEb0PqGKakVm0WyXwDt6u+cAoxbO2Z2CwKvOe3+b4+F2IlO9lYHi1kqFuRM70ddBnow==",
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.7.tgz",
+      "integrity": "sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w==",
       "dev": true
     },
     "pretty-error": {
@@ -12568,9 +12425,9 @@
       "dev": true
     },
     "randomatic": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
+      "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
       "dev": true,
       "requires": {
         "is-number": "^4.0.0",
@@ -12794,9 +12651,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.0.tgz",
-      "integrity": "sha512-SpV2LhF5Dm9UYMEprB3WwsBnWwqTrmjrm2UZb42cl2G02WVGgx7Mg8aa9pdLEKp6hZ+/abcMc2NxKA8f02EG2w=="
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regenerator-transform": {
       "version": "0.12.4",
@@ -13255,16 +13112,17 @@
       }
     },
     "sass-loader": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.0.3.tgz",
-      "integrity": "sha512-iaSFtQcGo4SSgDw5Aes5p4VTrA5jCGSA7sGmhPIcOloBlgI1VktM2MUrk2IHHjbNagckXlPz+HWq1vAAPrcYxA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-7.1.0.tgz",
+      "integrity": "sha512-+G+BKGglmZM2GUSfT9TLuEp6tzehHPjAMoRRItOojWIqIGPloVCMhNIQuG639eJ+y033PaGTSjLaTHts8Kw79w==",
       "dev": true,
       "requires": {
         "clone-deep": "^2.0.1",
         "loader-utils": "^1.0.1",
         "lodash.tail": "^4.1.1",
         "neo-async": "^2.5.0",
-        "pify": "^3.0.0"
+        "pify": "^3.0.0",
+        "semver": "^5.5.0"
       }
     },
     "sax": {
@@ -13274,9 +13132,9 @@
       "dev": true
     },
     "schema-utils": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
-      "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+      "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.1.0",
@@ -13702,23 +13560,6 @@
         "kind-of": "^3.2.0"
       }
     },
-    "sntp": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.x.x"
-      },
-      "dependencies": {
-        "hoek": {
-          "version": "2.16.3",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-          "dev": true
-        }
-      }
-    },
     "sockjs": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
@@ -13910,13 +13751,10 @@
       }
     },
     "ssri": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.3.0.tgz",
-      "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.1"
-      }
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.0.tgz",
+      "integrity": "sha512-zYOGfVHPhxyzwi8MdtdNyxv3IynWCIM4jYReR48lqu0VngxgH1c+C6CmipRdJ55eVByTJV/gboFEEI7TEQI8DA==",
+      "dev": true
     },
     "stable": {
       "version": "0.1.8",
@@ -14088,12 +13926,6 @@
         "is-obj": "^1.0.1",
         "is-regexp": "^1.0.0"
       }
-    },
-    "stringstream": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
-      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
@@ -14911,9 +14743,9 @@
       "dev": true
     },
     "validate-npm-package-license": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
@@ -14953,9 +14785,9 @@
       }
     },
     "vue": {
-      "version": "2.5.16",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.16.tgz",
-      "integrity": "sha512-/ffmsiVuPC8PsWcFkZngdpas19ABm5mh2wA7iDqcltyCTwlgZjHGeJYOXkBMo422iPwIcviOtrTCUpSfXmToLQ=="
+      "version": "2.5.17",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.17.tgz",
+      "integrity": "sha512-mFbcWoDIJi0w0Za4emyLiW72Jae0yjANHbCVquMKijcavBGypqlF7zHRgMa5k4sesdv7hv2rB4JPdZfR+TPfhQ=="
     },
     "vue-eslint-parser": {
       "version": "2.0.3",
@@ -14983,9 +14815,9 @@
       "dev": true
     },
     "vue-loader": {
-      "version": "15.2.6",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.2.6.tgz",
-      "integrity": "sha512-pArIvo89q3rBgYsDzc/EQoqJZH4lTiH5RJa3AguwazdO/+gN7NDyu59UyEdVCc1h+67xZlah2viNAvk3JE3CMw==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.3.0.tgz",
+      "integrity": "sha512-cqoefQo1pocGEFY9l/SR6LsbmMpQ8JD374kFPL/1Et4uY4/C5DCY4Cq9Bevbf10ZuHAWS4Gf//szgxGZwdObIw==",
       "dev": true,
       "requires": {
         "@vue/component-compiler-utils": "^2.0.0",
@@ -15006,9 +14838,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.5.16",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.16.tgz",
-      "integrity": "sha512-ZbuhCcF/hTYmldoUOVcu2fcbeSAZnfzwDskGduOrnjBiIWHgELAd+R8nAtX80aZkceWDKGQ6N9/0/EUpt+l22A==",
+      "version": "2.5.17",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.17.tgz",
+      "integrity": "sha512-63uI4syCwtGR5IJvZM0LN5tVsahrelomHtCxvRkZPJ/Tf3ADm1U1wG6KWycK3qCfqR+ygM5vewUvmJ0REAYksg==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",
@@ -15051,9 +14883,9 @@
       }
     },
     "webpack": {
-      "version": "4.16.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.16.3.tgz",
-      "integrity": "sha512-3VcrVoFgzSz1IYgga71YpU3HO89Al5bSnDOj9RJQPsy+FNyI1sFsUyJITn3pktNuaRBlQT0usvKZE3GgkPGAIw==",
+      "version": "4.16.5",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.16.5.tgz",
+      "integrity": "sha512-i5cHYHonzSc1zBuwB5MSzW4v9cScZFbprkHK8ZgzPDCRkQXGGpYzPmJhbus5bOrZ0tXTcQp+xyImRSvKb0b+Kw==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.5.13",
@@ -15619,9 +15451,9 @@
       }
     },
     "webpack-merge": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.3.tgz",
-      "integrity": "sha512-zxwAIGK7nKdu5CIZL0BjTQoq3elV0t0MfB7rUC1zj668geid52abs6hN/ACwZdK6LeMS8dC9B6WmtF978zH5mg==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.1.4.tgz",
+      "integrity": "sha512-TmSe1HZKeOPey3oy1Ov2iS3guIZjWvMT2BBJDzzT5jScHTjVC3mpjJofgueEzaEd6ibhxRDD6MIblDr8tzh8iQ==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.5"

--- a/notification-portlet-webcomponents/notification-modal/package.json
+++ b/notification-portlet-webcomponents/notification-modal/package.json
@@ -8,20 +8,20 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@uportal/open-id-connect": "^1.5.0",
+    "@uportal/open-id-connect": "^1.6.0",
     "axios": "^0.18.0",
     "bootstrap-vue": "^2.0.0-rc.11",
-    "vue": "^2.5.16"
+    "vue": "^2.5.17"
   },
   "devDependencies": {
-    "@vue/cli-plugin-babel": "^3.0.0-rc.10",
-    "@vue/cli-plugin-eslint": "^3.0.0-rc.10",
-    "@vue/cli-service": "^3.0.0-rc.10",
-    "@vue/eslint-config-prettier": "^3.0.0-rc.10",
+    "@vue/cli-plugin-babel": "^3.0.0-rc.12",
+    "@vue/cli-plugin-eslint": "^3.0.0-rc.12",
+    "@vue/cli-service": "^3.0.0-rc.12",
+    "@vue/eslint-config-prettier": "^3.0.0-rc.12",
     "lint-staged": "^7.2.0",
-    "node-sass": "^4.9.0",
-    "sass-loader": "^7.0.1",
-    "vue-template-compiler": "^2.5.16"
+    "node-sass": "^4.9.3",
+    "sass-loader": "^7.1.0",
+    "vue-template-compiler": "^2.5.17"
   },
   "eslintConfig": {
     "root": true,

--- a/notification-portlet-webcomponents/notification-modal/src/components/NotificationModal.vue
+++ b/notification-portlet-webcomponents/notification-modal/src/components/NotificationModal.vue
@@ -2,6 +2,7 @@
   <!-- escape key, clicking the background, and the close button are all availible
     unless there are availible actions, which requires a user to click buttons to continue -->
   <b-modal
+    class="notification-modal-wrapper"
     v-model="modalShow"
     :title=currentNotification.title
     :hide-header-close=hasActions
@@ -157,15 +158,24 @@ export default {
 };
 </script>
 
-<style lang="scss">
-// core bootstrap framework
-@import "../../node_modules/bootstrap/scss/functions.scss";
-@import "../../node_modules/bootstrap/scss/variables.scss";
-@import "../../node_modules/bootstrap/scss/mixins.scss";
-// bootstrap styles needed by page
-@import "../../node_modules/bootstrap/scss/utilities.scss";
-@import "../../node_modules/bootstrap/scss/type.scss";
-@import "../../node_modules/bootstrap/scss/buttons.scss";
-@import "../../node_modules/bootstrap/scss/close.scss";
-@import "../../node_modules/bootstrap/scss/modal.scss";
+<style lang="scss" scoped>
+// HACK: needed to scope styles for browsers that do not have shadow dom support
+.notification-modal-wrapper /deep/ {
+  // core bootstrap framework
+  @import "../../node_modules/bootstrap/scss/functions.scss";
+  @import "../../node_modules/bootstrap/scss/variables.scss";
+  @import "../../node_modules/bootstrap/scss/mixins.scss";
+  // bootstrap styles needed by page
+  @import "../../node_modules/bootstrap/scss/utilities.scss";
+  @import "../../node_modules/bootstrap/scss/type.scss";
+  @import "../../node_modules/bootstrap/scss/buttons.scss";
+  @import "../../node_modules/bootstrap/scss/close.scss";
+  @import "../../node_modules/bootstrap/scss/modal.scss";
+
+  // HACK: override bootstrap 3 fade selector when shadow dom is off
+  // if this isn't set, bootstrap 3 makes the modal completely transparent
+  .fade {
+    opacity: 1;
+  }
+}
 </style>


### PR DESCRIPTION
Bootstrap 3 sets `.fade` as a transparency.
Bootstrap 4 leverages it for animations.

When shadow dom isn't enabled, the modal is made completely transparent.
This overrides the bootstrap 3 bleed through.