### PR TITLE
fix:  troubleshoot support for the new (non-portlet) REST API on the …

### DIFF
--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jdbc/AnyRowResourceContentJdbcNotificationService.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jdbc/AnyRowResourceContentJdbcNotificationService.java
@@ -19,10 +19,10 @@
 package org.jasig.portlet.notice.service.jdbc;
 
 import java.io.IOException;
-import java.util.Map;
 
 import javax.annotation.PostConstruct;
 import javax.portlet.PortletRequest;
+import javax.servlet.http.HttpServletRequest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.jasig.portlet.notice.NotificationResponse;
@@ -30,15 +30,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.jdbc.core.ResultSetExtractor;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 
 /**
  * Concrete implementation of {@link AbstractJdbcNotificationService} that returns a 100% static
  * {@link NotificationResponse} from the classpath if the configured SQL returns at least one row.
  * Otherwise it returns <code>NotificationResponse.EMTY_RESPONSE</code>.  The default
- * {@link SqlParameterSource} wraps the <code>PortletRequest.USER_INFO</code> collection, but
- * subclasses may override this strategy.
+ * {@link SqlParameterSource} wraps the <code>PortletRequest.USER_INFO</code> collection (Portlet
+ * API) or the OIDC Id Token (Servlet API), but subclasses may override this strategy.
  *
  * @since 3.2
  */
@@ -73,27 +72,24 @@ public class AnyRowResourceContentJdbcNotificationService extends AbstractJdbcNo
         }
     }
 
-    /**
-     * Implements this part of the operation by wrapping the <code>PortletRequest.USER_INFO</code>
-     * map in a {@link MapSqlParameterSource}.
-     */
     @Override
-    protected SqlParameterSource getSqlParameterSource(PortletRequest req) {
-        final Map<String, String> userInfo = (Map<String, String>) req.getAttribute(PortletRequest.USER_INFO);
-        logger.debug("Notification service '{}' prepared the following SQL parameters" +
-                "for user '{}':  {}", getName(), usernameFinder.findUsername(req), userInfo);
-        return new MapSqlParameterSource(userInfo);
+    protected ResultSetExtractor<NotificationResponse> getResultSetExtractor(PortletRequest req) {
+        return getResultSetExtractor();
     }
 
     @Override
-    protected ResultSetExtractor<NotificationResponse> getResultSetExtractor(PortletRequest req) {
+    protected ResultSetExtractor<NotificationResponse> getResultSetExtractor(HttpServletRequest request) {
+        return getResultSetExtractor();
+    }
+
+    private ResultSetExtractor<NotificationResponse> getResultSetExtractor() {
         return rs -> {
             if (rs.next()) {
-                // The user should get a the Banner Holds notification
+                // The user should get the configured notification
                 logger.debug("ResultSet NOT empty for notification service '{}'", getName());
                 return nonEmptyResponse;
             } else {
-                // The user does not need the Banner Holds notification
+                // The user should NOT get the configured notification
                 logger.debug("ResultSet empty for notification service '{}'", getName());
                 return NotificationResponse.EMPTY_RESPONSE;
             }


### PR DESCRIPTION
…part of the AbstractJdbcNotificationService (and subclasses)

resolves #76 

This changes fixes support for the REST API (used by notification icon & modal) for `INotificationService` beans based on `AbstractJdbcNotificationService`.