### PR TITLE
fix: use CSS to move the notification modal dialog a bit lower (4rem)…

### DIFF
--- a/notification-portlet-webcomponents/notification-modal/src/components/NotificationModal.vue
+++ b/notification-portlet-webcomponents/notification-modal/src/components/NotificationModal.vue
@@ -177,5 +177,10 @@ export default {
   .fade {
     opacity: 1;
   }
+
+  // Position the modal dialog slightly lower b/c (by default) it rides too high on Firefox
+  .modal-content {
+    top: 4rem;
+  }
 }
 </style>


### PR DESCRIPTION
… b/c it's partially cut off at the top on Firefox

Fixes this issue...

![notification-modal](https://user-images.githubusercontent.com/1127174/44949147-89bdd880-ade0-11e8-8615-1cf245d83625.png)
