### PR TITLE
fix: Removed placeholder in error str since it's built using concatenation

### DIFF
--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/classloader/ClassLoaderResourceNotificationService.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/classloader/ClassLoaderResourceNotificationService.java
@@ -167,7 +167,7 @@ public class ClassLoaderResourceNotificationService extends AbstractNotification
                 File f = new File(location.toURI());
                 rslt =  mapper.readValue(f, NotificationResponse.class);
             } catch (Exception e) {
-                String msg = "Failed to read the data file:  {}" + location;
+                String msg = "Failed to read the data file:  " + location;
                 logger.error(msg, e);
                 rslt = prepareErrorResponse(getName(), msg);
             }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
Removed placeholder in error string since it's built using concatenation

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
