### PR TITLE
fix: Filter read notification(s) from the modal web component

### DIFF
--- a/notification-portlet-webcomponents/notification-modal/src/components/NotificationModal.vue
+++ b/notification-portlet-webcomponents/notification-modal/src/components/NotificationModal.vue
@@ -96,10 +96,26 @@ export default {
           }
         );
 
+        var unreadNotifications = [];
+
+        for (var i = 0; i < notifications.length; i++) {
+          var notification = notifications[i];
+
+          if (
+            notification.attributes &&
+            notification.attributes["READ"] &&
+            notification.attributes["READ"][0] === "true"
+          ) {
+            continue;
+          }
+
+          unreadNotifications.push(notification);
+        }
+
         // store notifications to state
         // @see modalShow - for logic determining if notification should be shown
         // @see currentNotification - for logic rendering a modal
-        this.notifications = notifications;
+        this.notifications = unreadNotifications;
       } catch (err) {
         // eslint-disable-next-line no-console
         console.error(err);

--- a/notification-portlet-webcomponents/notification-modal/src/components/NotificationModal.vue
+++ b/notification-portlet-webcomponents/notification-modal/src/components/NotificationModal.vue
@@ -96,21 +96,14 @@ export default {
           }
         );
 
-        var unreadNotifications = [];
-
-        for (var i = 0; i < notifications.length; i++) {
-          var notification = notifications[i];
-
-          if (
-            notification.attributes &&
-            notification.attributes["READ"] &&
-            notification.attributes["READ"][0] === "true"
-          ) {
-            continue;
-          }
-
-          unreadNotifications.push(notification);
-        }
+        const unreadNotifications = notifications.filter(
+          n =>
+            !(
+              n.attributes &&
+              n.attributes.READ &&
+              n.attributes.READ[0] === "true"
+            )
+        );
 
         // store notifications to state
         // @see modalShow - for logic determining if notification should be shown


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
When a notification is marked as read a `READ` attribute is added to the notification

```json
    "attributes": {
      "READ": [
        "true "
      ],
    }
```

This fix filters the read notifications out such that they are not displayed to the user

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
