### PR TITLE
feat: Implemented filtering for read/unread notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ Example:
 /NotificationPortlet/api/v2/notifications?maxPriority=3
 ```
 
+##### `read`
+
+Use the `read` query parameter to filter out notifications that have been marked read. A value of `true` will return
+notifications that have been read while a value of `false` will return unread notifications. The absense of this
+parameter will return all notifications regardless of their `READ` attribute value.
+
+Example:
+
+```
+/NotificationPortlet/api/v2/notifications?read=false
+```
+
 ### Java Portlet-Based UI Components
 
 As it's name implies, this project was originally developed as a collection of Java Portlet

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/filter/ReadStateSupportFilter.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/filter/ReadStateSupportFilter.java
@@ -51,6 +51,7 @@ import java.util.List;
 public class ReadStateSupportFilter extends AbstractNotificationServiceFilter {
 
     public static final String READ_ATTRIBUTE_NAME = "READ";
+    public static final String READ_PARAMETER_NAME = "read";
     public static final NotificationAttribute READ_ATTRIBUTE =
             new NotificationAttribute(READ_ATTRIBUTE_NAME, Boolean.TRUE.toString());
     public static final NotificationAttribute UNREAD_ATTRIBUTE =
@@ -72,6 +73,8 @@ public class ReadStateSupportFilter extends AbstractNotificationServiceFilter {
     public NotificationResponse doFilter(HttpServletRequest request, INotificationServiceFilterChain chain) {
 
         final NotificationResponse response = chain.doFilter();
+
+        final String readFilterParameter = request.getParameter(READ_PARAMETER_NAME);
 
         final NotificationResponse rslt = response.cloneIfNotCloned();
 
@@ -120,8 +123,20 @@ public class ReadStateSupportFilter extends AbstractNotificationServiceFilter {
             }
         }
 
+        if (StringUtils.isNotBlank(readFilterParameter)) {
+            boolean readFilterValue = Boolean.parseBoolean(readFilterParameter);
+
+            return rslt.filter(
+                    entry -> {
+                        boolean isRead =
+                                entry.getAttributes()
+                                        .stream()
+                                        .anyMatch(attribute -> attribute.equals(READ_ATTRIBUTE));
+
+                        return isRead == readFilterValue;
+                    });
+        }
+
         return rslt;
-
     }
-
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://issues.jasig.org/browse/UP/

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]
-   [x] documentation is changed or added

##### Description of change
<!-- Provide a description of the change below this comment. -->
From https://github.com/Jasig/NotificationPortlet/pull/119#issuecomment-428258993, this is a more desirable approach to do filtering of read notifications

Edits and/or suggestions are welcome

<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl
