### PR TITLE
fix:  correct the behavior of action.apiUrl in the new notification-icon

### DIFF
--- a/notification-portlet-webcomponents/notification-icon/src/components/NotificationItem.vue
+++ b/notification-portlet-webcomponents/notification-icon/src/components/NotificationItem.vue
@@ -16,6 +16,11 @@ export default {
         ({ id }) => id === "MarkAsReadAndRedirectAction"
       );
     },
+    apiUrl() {
+        let redirectAction = this.notification?.availableActions?.find?.(
+            ({ id }) => id === "MarkAsReadAndRedirectAction");
+        return redirectAction?.apiUrl;
+    },
     isRead() {
       return JSON.parse(this.notification?.attributes?.READ?.[0] || "true");
     },
@@ -26,7 +31,7 @@ export default {
       if (this.redirectAction) {
         return () => {
           let form = document.createElement("form");
-          form.action = this.notification.url;
+          form.action = this.apiUrl;
           form.method = "POST";
           form.style.display = "none";
           document.body.appendChild(form);


### PR DESCRIPTION
This change fixes the `MarkAsReadAndRedirect` behavior in the new `notification-icon` web component.