### PR TITLE
Wrapping the slot to render the non-item items

### DIFF
--- a/notification-portlet-webcomponents/notification-icon/src/components/ieDropdownItem.vue
+++ b/notification-portlet-webcomponents/notification-icon/src/components/ieDropdownItem.vue
@@ -1,9 +1,13 @@
 <template>
-    <slot></slot>
+    <a v-if="href" class="dropdown-item" :href="href"><slot></slot></a>
+    <div v-else class="dropdown-item">
+        <slot></slot>
+    </div>
 </template>
 
 <script>
 export default {
-  name: "ie-dropdown-item"
+  name: "ie-dropdown-item",
+  props: ['href'],
 };
 </script>


### PR DESCRIPTION
Fix for IE issue where it wasn't rendering the "no unread notifications" text and the "show all notifications" link