### PR TITLE
fix: make JSON deserialization of NotificationEntry objects tolerant …

### DIFF
--- a/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationEntry.java
+++ b/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationEntry.java
@@ -30,6 +30,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -48,6 +49,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * class contains all the entries for the same category title.
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonIgnoreProperties(ignoreUnknown = true) // When deserializing, ignore extra fields
 @XmlAccessorType(XmlAccessType.FIELD)
 public class NotificationEntry implements Serializable, Cloneable {
 

--- a/notification-portlet-webapp/build.gradle
+++ b/notification-portlet-webapp/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     compile "org.hibernate:hibernate-entitymanager:${hibernateVersion}"
     compile "org.jasig.resourceserver:resource-server-utils:${resourceServerVersion}"
     compile("org.jasig.portal:uPortal-soffit-renderer:${uPortalVersion}")
-    compile "org.jasig.portal:uPortal-spring:${uPortalVersion}"
+    compile "org.jasig.portal:uPortal-spring:${uPortalVersion}@jar" // Use @jar classifier to exclude transitive dependencies
     compile "org.jasypt:jasypt-spring31:${jasyptVersion}"
     compile "org.springframework:spring-jdbc:${springVersion}"
     compile "org.springframework:spring-orm:${springVersion}"


### PR DESCRIPTION
…of extra fields

This change tells the Notification portlet to ignore extra fields in the JSON when it deserializes NotificationEntry objects.

(There are some adopters who have customized the format for some reason.  This change makes the project tolerant of those changes.)