### PR TITLE
feat(per-session): add per-session acknowledgement support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,6 +26,7 @@ jasyptVersion=1.9.3
 jodaTimeVersion=2.10.3
 jsonPathVersion=2.4.0
 jstlVersion=1.2
+lombokVersion=1.18.8
 nodejsVersion=10.15.1
 resourceServerVersion=1.3.1
 romeVersion=1.0

--- a/notification-portlet-api/build.gradle
+++ b/notification-portlet-api/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}"
     compile "commons-lang:commons-lang:${commonsLangVersion}"
     compile "org.slf4j:slf4j-api:${slf4jVersion}"
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     compileOnly "${portletApiDependency}"
     compileOnly "javax.servlet:servlet-api:${servletApiVersion}"
 }

--- a/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationAction.java
+++ b/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationAction.java
@@ -31,6 +31,9 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Setter;
 
 /**
  * Represents a behavior that a user may invoke on a notification.  The
@@ -38,6 +41,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * and Favorite.  Concrete service impls must provide the business logic to
  * perform the action, as well as implement the invoke method.
  */
+@Data
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonDeserialize(using = JsonNotificationActionDeserializer.class)
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -45,20 +49,10 @@ public abstract class NotificationAction implements Serializable, Cloneable {
 
     private static final long serialVersionUID = 1L;
 
+    @JsonIgnore
     // Instance Members
+    @Setter(AccessLevel.PACKAGE)
     private NotificationEntry target;
-    private String id = getClass().getSimpleName();
-    private String label;
-    private String apiUrl;
-    private boolean redirect = false;
-
-    public final String getClazz() {
-        return getClass().getName();
-    }
-
-    public final String getId() {
-        return id;
-    }
 
     /**
      * Identifies the action, from among the available set of actions, when the
@@ -66,60 +60,25 @@ public abstract class NotificationAction implements Serializable, Cloneable {
      * the simpleName of the implementing class, so subclasses that can appear
      *  more than once within a notification should override it.
      */
-    public final void setId(String id) {
-        this.id = id;
-    }
-
-    public final String getLabel() {
-        return label;
-    }
-
-    public final void setLabel(String label) {
-        this.label = label;
-    }
-
-    @JsonIgnore
-    public final NotificationEntry getTarget() {
-        return target;
-    }
+    private String id = getClass().getSimpleName();
+    private String label;
 
     /**
      * Complete URL (ncluding CSRF token, if appropriate) that can be used to invoke this action
      * through the <code>NotificationRestV2Controller</code>.
-     */
-    public String getApiUrl() {
-        return apiUrl;
-    }
-
-    /**
-     * Sets the URL for invoking this action through the <code>NotificationRestV2Controller</code>.
+     *
      * <em>This field should not be provided by the data source</em> (i.e. Notification Service).
      * It must be set by the API layer.
      */
-    public void setApiUrl(String apiUrl) {
-        this.apiUrl = apiUrl;
-    }
+    private String apiUrl;
 
     /**
      * Flags whether the URL should be a silent, background API call or a redirect.
-     *
-     * @return boolean if the URL is a redirect or API call
-     *
-     * @since 4.6.0
      */
-    public boolean getRedirect() {
-        return redirect;
-    }
+    private boolean redirect = false;
 
-    /**
-     * Sets whether the URL should be a silent, background API call or a redirect.
-     *
-     * @param redirect if true, URL is a redirect; otherwise, the URL is a silent API call
-     *
-     * @since 4.6.0
-     */
-    public void setRedirect(boolean redirect) {
-        this.redirect = redirect;
+    public final String getClazz() {
+        return getClass().getName();
     }
 
     /**
@@ -158,13 +117,4 @@ public abstract class NotificationAction implements Serializable, Cloneable {
         return rslt;
 
     }
-
-    /*
-     * Non-public API
-     */
-
-    /* package-private */ void setTarget(NotificationEntry target) {
-        this.target = target;
-    }
-
 }

--- a/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationAction.java
+++ b/notification-portlet-api/src/main/java/org/jasig/portlet/notice/NotificationAction.java
@@ -50,6 +50,7 @@ public abstract class NotificationAction implements Serializable, Cloneable {
     private String id = getClass().getSimpleName();
     private String label;
     private String apiUrl;
+    private boolean redirect = false;
 
     public final String getClazz() {
         return getClass().getName();
@@ -97,6 +98,28 @@ public abstract class NotificationAction implements Serializable, Cloneable {
      */
     public void setApiUrl(String apiUrl) {
         this.apiUrl = apiUrl;
+    }
+
+    /**
+     * Flags whether the URL should be a silent, background API call or a redirect.
+     *
+     * @return boolean if the URL is a redirect or API call
+     *
+     * @since 4.6.0
+     */
+    public boolean getRedirect() {
+        return redirect;
+    }
+
+    /**
+     * Sets whether the URL should be a silent, background API call or a redirect.
+     *
+     * @param redirect if true, URL is a redirect; otherwise, the URL is a silent API call
+     *
+     * @since 4.6.0
+     */
+    public void setRedirect(boolean redirect) {
+        this.redirect = redirect;
     }
 
     /**

--- a/notification-portlet-webapp/build.gradle
+++ b/notification-portlet-webapp/build.gradle
@@ -63,6 +63,8 @@ dependencies {
     compile "org.springframework:spring-webmvc-portlet:${springVersion}"
     compile "org.springframework.security.oauth:spring-security-oauth2:${springSecurityOAuth2Version}"
     compile "rome:rome:${romeVersion}"
+    compileOnly "org.projectlombok:lombok:${lombokVersion}"
+    annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
     /*
      * Spring Boot

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/acknowledge/AcknowledgeAction.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/acknowledge/AcknowledgeAction.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.notice.action.acknowledge;
+
+import java.io.IOException;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.PortletSession;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jasig.portlet.notice.filter.ReadStateAction;
+
+/**
+ * Acknowledge action class that represents a per session "read" of a notice.
+ *
+ * This class depends on {@code ApiUrlSupportFilter} (or other external code)
+ * to set it's apiUrl attribute for callback.
+ *
+ * @since 4.6.0
+ */
+@Slf4j
+public class AcknowledgeAction extends ReadStateAction {
+
+    private static final String SESSION_ATTR_PREFIX = AcknowledgeAction.class.getName() + ".";
+
+    @Override
+    public void invoke(ActionRequest req, ActionResponse res) throws IOException {
+        log.debug("Calling {} portlet invoke() for notice {}", AcknowledgeAction.class.getCanonicalName(), getTarget().getId());
+        final PortletSession session = req.getPortletSession(true);
+        // Don't care the value so we will just use current time
+        session.setAttribute(getSessionAttrName(), System.currentTimeMillis());
+    }
+
+    @Override
+    public void invoke(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        log.debug("Calling {} invoke() for notice {}", AcknowledgeAction.class.getCanonicalName(), getTarget().getId());
+        final HttpSession session = request.getSession(true);
+        // Don't care the value so we will just use current time
+        session.setAttribute(getSessionAttrName(), System.currentTimeMillis());
+    }
+
+    private String getSessionAttrName() {
+        assert getTarget() != null;
+        // Target is the notice. It's ID should be unique across all sources, but we will add source anyway.
+        return SESSION_ATTR_PREFIX + getTarget().getSource() + "." + getTarget().getId();
+    }
+
+    public boolean isAck(HttpSession session) {
+        assert session != null;
+        return session.getAttribute(getSessionAttrName()) != null;
+    }
+
+    public boolean isAck(PortletSession session) {
+        assert session != null;
+        return session.getAttribute(getSessionAttrName()) != null;
+    }
+}

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/read/MarkAsReadAndRedirectAction.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/read/MarkAsReadAndRedirectAction.java
@@ -18,12 +18,13 @@
  */
 package org.jasig.portlet.notice.action.read;
 
-import org.apache.commons.lang3.StringUtils;
-import org.jasig.portlet.notice.NotificationEntry;
+import java.io.IOException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jasig.portlet.notice.NotificationEntry;
 
 /**
  * Extension of {@link ReadAction} that redirects the user to the URL associated with the
@@ -37,6 +38,7 @@ public class MarkAsReadAndRedirectAction extends ReadAction {
 
     public MarkAsReadAndRedirectAction() {
         setLabel(LABEL);
+        setRedirect(true);
     }
 
     @Override

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/read/ReadAction.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/action/read/ReadAction.java
@@ -30,18 +30,18 @@ import javax.portlet.PortletRequest;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.jasig.portlet.notice.NotificationEntry;
 import org.jasig.portlet.notice.NotificationState;
+import org.jasig.portlet.notice.filter.ReadStateAction;
 import org.jasig.portlet.notice.rest.EventDTO;
 import org.jasig.portlet.notice.util.JpaServices;
 import org.jasig.portlet.notice.util.SpringContext;
 import org.jasig.portlet.notice.util.UsernameFinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.commons.lang.builder.HashCodeBuilder;
-import org.jasig.portlet.notice.NotificationAction;
-import org.jasig.portlet.notice.NotificationEntry;
 
-public class ReadAction extends NotificationAction {
+public class ReadAction extends ReadStateAction {
 
     private static final long serialVersionUID = 1L;
 

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/filter/AcknowledgePerSessionFilter.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/filter/AcknowledgePerSessionFilter.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.notice.filter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jasig.portlet.notice.INotificationServiceFilterChain;
+import org.jasig.portlet.notice.NotificationAction;
+import org.jasig.portlet.notice.NotificationCategory;
+import org.jasig.portlet.notice.NotificationEntry;
+import org.jasig.portlet.notice.NotificationResponse;
+import org.jasig.portlet.notice.action.acknowledge.AcknowledgeAction;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@code NotificationServiceFilter} that implements per session "read" of notices
+ * that have a {@code AcknowledgeAction} in their action lists.
+ *
+ * This class also provides filtering for acknowledged or un-acknowledged notices
+ * with {@code AcknowledgeAction} actions.
+ *
+ * @since 4.6.0
+ */
+@Slf4j
+@Component
+public class AcknowledgePerSessionFilter extends AbstractNotificationServiceFilter {
+
+    private static final String REQ_ACK_PARAM = "ack";
+
+    public AcknowledgePerSessionFilter() {
+        super(AbstractNotificationServiceFilter.ORDER_LATE);
+    }
+
+    @Override
+    public NotificationResponse doFilter(HttpServletRequest request, INotificationServiceFilterChain chain) {
+
+        log.debug("{}.doFilter called", AcknowledgePerSessionFilter.class.getCanonicalName());
+
+        final String ackParameter = request.getParameter(REQ_ACK_PARAM);
+
+        final HttpSession session = request.getSession(true);
+        final NotificationResponse response = chain.doFilter().cloneIfNotCloned();
+
+        if (ackParameter == null) {
+            log.debug("{} was not found in the parameter list", REQ_ACK_PARAM);
+            return removeAckActionsWhenAck(response, session);
+        }
+
+        final boolean filterAck = Boolean.parseBoolean(ackParameter);
+        log.debug("{} parsed to {} in request", REQ_ACK_PARAM, filterAck);
+
+        for (NotificationCategory category : response.getCategories()) {
+            // new entry list
+            final List<NotificationEntry> newEntries = new ArrayList<>();
+            for (NotificationEntry entry : category.getEntries()) {
+                log.debug("entry: {}", entry);
+
+                final List<NotificationAction> currentActions = entry.getAvailableActions();
+                final Optional<NotificationAction> acknowledgeActionOptional = currentActions.stream()
+                        .filter(AcknowledgeAction.class::isInstance)
+                        .findFirst();
+                final AcknowledgeAction ackAction = (AcknowledgeAction) acknowledgeActionOptional.orElse(null);
+                assert (ackAction == null) || entry.equals(ackAction.getTarget());
+                if (filterAck && ackAction.isAck(session)) {
+                    log.debug("entry {} ack and {}=true", entry.getId(), REQ_ACK_PARAM);
+                    newEntries.add(entry);
+
+                } else if (!filterAck && (ackAction == null || !ackAction.isAck(session))) {
+                    log.debug("entry {} not ack and {}=false", entry.getId(), REQ_ACK_PARAM);
+                    newEntries.add(entry);
+                } else {
+                    log.debug("entry {} not selected when {}={}", entry.getId(), REQ_ACK_PARAM, filterAck);
+                }
+            }
+            // replace entries in current category
+            category.setEntries(newEntries);
+        }
+
+        return removeAckActionsWhenAck(response, session);
+    }
+
+    private NotificationResponse removeAckActionsWhenAck(NotificationResponse resp, HttpSession session) {
+        // perform in-place removal of AcknowledgeActions
+        for (NotificationCategory category : resp.getCategories()) {
+            for (NotificationEntry entry : category.getEntries()) {
+                List<NotificationAction> list = entry.getAvailableActions().stream()
+                        .filter(a -> !AcknowledgeAction.class.isInstance(a)
+                                || !((AcknowledgeAction) a).isAck(session))
+                        .collect(Collectors.toList());
+                entry.setAvailableActions(list);
+            }
+        }
+        return resp;
+    }
+}

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/filter/ApiUrlSupportFilter.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/filter/ApiUrlSupportFilter.java
@@ -18,16 +18,22 @@
  */
 package org.jasig.portlet.notice.filter;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.portal.soffit.Headers;
-import org.jasig.portlet.notice.*;
+import org.jasig.portlet.notice.INotificationServiceFilter;
+import org.jasig.portlet.notice.INotificationServiceFilterChain;
+import org.jasig.portlet.notice.NotificationAction;
+import org.jasig.portlet.notice.NotificationCategory;
+import org.jasig.portlet.notice.NotificationEntry;
+import org.jasig.portlet.notice.NotificationResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.stereotype.Component;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * This {@link INotificationServiceFilter} sets the <code>apiUrl</code> property on
@@ -57,6 +63,7 @@ public class ApiUrlSupportFilter extends AbstractNotificationServiceFilter {
      * commonly add actions.
      */
     public ApiUrlSupportFilter() {
+        // needs to order after {@code ReadStateSupportFilter}
         super(AbstractNotificationServiceFilter.ORDER_VERY_LATE);
     }
 

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/filter/ReadStateAction.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/filter/ReadStateAction.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.jasig.portlet.notice.filter;
+
+import org.jasig.portlet.notice.NotificationAction;
+
+/**
+ * Class which signifies that subclasses should be considered actions that handle read state updates.
+ *
+ * Concretely, these classes will replace the default {MarkAsReadAndRedirectAction} added to all notices
+ * by {@ReadStateSupportFilter}
+ *
+ * @since 4.5.4
+ */
+public abstract class ReadStateAction extends NotificationAction {
+}

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/filter/ReadStateSupportFilter.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/filter/ReadStateSupportFilter.java
@@ -18,6 +18,11 @@
  */
 package org.jasig.portlet.notice.filter;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
 import org.apache.commons.lang.StringUtils;
 import org.jasig.portlet.notice.INotificationServiceFilter;
 import org.jasig.portlet.notice.INotificationServiceFilterChain;
@@ -28,7 +33,6 @@ import org.jasig.portlet.notice.NotificationEntry;
 import org.jasig.portlet.notice.NotificationResponse;
 import org.jasig.portlet.notice.NotificationState;
 import org.jasig.portlet.notice.action.read.MarkAsReadAndRedirectAction;
-import org.jasig.portlet.notice.action.read.ReadAction;
 import org.jasig.portlet.notice.rest.EventDTO;
 import org.jasig.portlet.notice.util.IJpaServices;
 import org.jasig.portlet.notice.util.UsernameFinder;
@@ -36,10 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * For notifications based on the Servlet API, this {@link INotificationServiceFilter}
@@ -113,7 +113,7 @@ public class ReadStateSupportFilter extends AbstractNotificationServiceFilter {
                 if (!isRead) {
                     final List<NotificationAction> currentActions = entry.getAvailableActions();
                     boolean hasReadActionAlready = currentActions.stream()
-                            .anyMatch(action -> ReadAction.class.isInstance(action));
+                            .anyMatch(action -> ReadStateAction.class.isInstance(action));
                     if (!hasReadActionAlready) {
                         final List<NotificationAction> replacementList = new ArrayList<>(currentActions);
                         replacementList.add(new MarkAsReadAndRedirectAction());


### PR DESCRIPTION
Resolves #330

Adds an AcknowledgeAction that is valid for the duration of the user's session. Also adds `redirect` boolean flag to `NotificationAction` to inform web components when to quietly use fetch vs. an actual redirect. 