### PR TITLE
fix: disable csrf for v2 REST endpoints

### DIFF
--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/security/SecurityConfiguration.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/security/SecurityConfiguration.java
@@ -111,7 +111,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
              * REST APIs are secured by OIDC Id tokens.
              */
             .csrf()
-                .ignoringAntMatchers("/api/v1/**");
+                .ignoringAntMatchers("/api/v1/**")
+                .ignoringAntMatchers("/api/v2/**");
 
     }
 


### PR DESCRIPTION
This causes some actions to fail due to CSRF tokens "expiring". The REST API is secured with OIDC tokens already. 