### PR TITLE
chore(ci): target Java 11 only, drop Java 8

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,25 +12,13 @@ on:
 
 jobs:
   test:
-    name: '${{ matrix.platform }} with Java ${{ matrix.java-distribution }} version ${{ matrix.java-version }}'
+    name: 'Java 11 on ${{ matrix.platform }}'
     strategy:
       matrix:
         platform:
           - ubuntu-latest
-        java-distribution:
-          - adopt-hotspot
-          - temurin
-          - zulu
-        java-version:
-          - 8
-          - 11
-        include:
-          - platform: windows-latest
-            java-distribution: adopt-hotspot
-            java-version: 11
-          - platform: macos-latest
-            java-distribution: adopt-hotspot
-            java-version: 11
+          - windows-latest
+          - macos-latest
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 5
     steps:
@@ -39,8 +27,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: ${{ matrix.java-distribution }}
-          java-version: ${{ matrix.java-version }}
+          distribution: temurin
+          java-version: 11
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
       - name: Generate and submit dependency graph


### PR DESCRIPTION
Simplify CI matrix to Java 11 only on all 3 platforms (Temurin). Java 8 is no longer supported.

Unblocks security PRs like #550 (hsqldb 2.7.1) that fail CI on Java 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)