### PR TITLE
chore: tighten renovate pins

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,61 @@
 {
-    "extends": [
-      "config:base",
-      ":rebaseStalePrs",
-      ":preserveSemverRanges"
-    ],
-    "gradle": {
-      "enabled": true
+  "extends": [
+    "config:base",
+    ":rebaseStalePrs",
+    ":preserveSemverRanges"
+  ],
+  "gradle": {
+    "enabled": true
+  },
+  "renovateFork": true,
+  "packageRules": [
+    {
+      "matchPackageNames": ["javax.portlet:portlet-api"],
+      "allowedVersions": "< 3.0",
+      "description": "uPortal runs JSR-286 (Portlet API 2.0). Portlet API 3.x (JSR-362) is a different container contract and is not supported."
     },
-    "renovateFork": true
-  }
+    {
+      "matchPackagePrefixes": [
+        "org.springframework:",
+        "org.springframework.data:",
+        "org.springframework.security:",
+        "org.springframework.security.oauth:"
+      ],
+      "allowedVersions": "< 5.0",
+      "description": "Pinned to Spring Framework 4.3.x / Spring Security 4.2.x. Spring 5+ requires a coordinated migration; Spring 6+ additionally needs Jakarta EE + Java 17+."
+    },
+    {
+      "matchPackagePrefixes": ["org.hibernate:", "org.hibernate.orm:"],
+      "allowedVersions": "< 6.0",
+      "description": "Pinned to Hibernate 5.6.x. Hibernate 6+ (including the org.hibernate.orm groupId rename) requires Jakarta EE and Java 17+."
+    },
+    {
+      "matchPackageNames": [
+        "com.sun.xml.bind:jaxb-impl",
+        "jakarta.xml.bind:jakarta.xml.bind-api",
+        "org.glassfish.jaxb:jaxb-runtime"
+      ],
+      "allowedVersions": "< 3.0",
+      "description": "The 2.x releases preserve the javax.xml.bind.* package namespace. 3+ moves to jakarta.xml.bind as part of Jakarta EE 9+, which this portlet is not migrating to yet."
+    },
+    {
+      "matchPackageNames": ["org.codehaus.plexus:plexus-archiver"],
+      "allowedVersions": "< 4.10.0",
+      "description": "plexus-archiver 4.10+ requires a newer commons-io (BoundedInputStream.builder()) than the one bundled with maven-war-plugin 3.4.0. Revisit once the fleet's parent bumps maven-war-plugin to 3.5.x+."
+    },
+    {
+      "matchPackageNames": [
+        "org.mockito:mockito-core",
+        "org.mockito:mockito-inline",
+        "org.mockito:mockito-junit-jupiter"
+      ],
+      "allowedVersions": "< 5.0",
+      "description": "Mockito 5 uses the inline MockMaker by default; its bundled byte-buddy references ClassFileVersion.JAVA_V21, missing on the byte-buddy pulled transitively via Hibernate/Javassist. Stay on Mockito 4.x until byte-buddy can be reconciled."
+    },
+    {
+      "matchPackageNames": ["javax.servlet:javax.servlet-api"],
+      "allowedVersions": "< 5.0",
+      "description": "Servlet API 5+ is in the Jakarta EE namespace and incompatible with this portlet's javax.servlet imports. Runtime is Tomcat 8.5/9 (Servlet 3.1)."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add Spring/Hibernate/portlet-api/servlet-api/jaxb/plexus-archiver/mockito pins to renovate.json. Pattern matches what we applied to the rest of the portlet fleet (spring < 5.0 / hibernate < 6.0 / portlet-api < 3.0, etc.), extended with spring-security and spring-security-oauth prefixes since this portlet pins Spring Security 4.2.x alongside Spring 4.3.x.

Same pattern we've applied across the portlet fleet (AnnouncementsPortlet, basiclti-portlet, BookmarksPortlet, CalendarPortlet, FeedbackPortlet, JasigWidgetPortlets, NewsReaderPortlet, SimpleContentPortlet, WebproxyPortlet): match by `matchPackagePrefixes` where possible, cap major versions at the line that requires Jakarta EE / Java 17 / Spring migrations the fleet hasn't done yet.

Once merged, Renovate will auto-close any open proposals that violate the new pins on its next rebase cycle. Dependabot proposals are not affected by `renovate.json` and need manual closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)