### PR TITLE
chore: cap gradle-wrapper Renovate to < 9 (Java 17 floor)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -56,6 +56,11 @@
       "matchPackageNames": ["javax.servlet:javax.servlet-api"],
       "allowedVersions": "< 5.0",
       "description": "Servlet API 5+ is in the Jakarta EE namespace and incompatible with this portlet's javax.servlet imports. Runtime is Tomcat 8.5/9 (Servlet 3.1)."
+    },
+    {
+      "matchManagers": ["gradle-wrapper"],
+      "allowedVersions": "< 9.0",
+      "description": "Gradle 9 requires Java 17; this portlet builds on the fleet's Java 11 floor. Revisit when the fleet moves to Java 17 (gated on the Spring 6 / Jakarta EE migration)."
     }
   ]
 }


### PR DESCRIPTION
Stops Renovate from creating PRs that bump the Gradle wrapper to 9.x. Most recently surfaced as #682 ("chore(deps): update gradle to v9") which has been sitting unmergeable.

## Why

Gradle 9 requires **Java 17** as the build floor. NotificationPortlet builds on the fleet's **Java 11** floor (per the workspace `CLAUDE.md`), so any Gradle 9 bump would fail CI before we even got to evaluating build-script migration cost.

The reasoning matches the existing Spring 5+, Hibernate 6+, and Jakarta caps already in this file: revisit when the fleet moves to Java 17 as part of the Spring 6 / Jakarta EE migration.

Currently on Gradle `6.9.4` (per `gradle/wrapper/gradle-wrapper.properties`). The cap doesn't lock us out of 7.x or 8.x bumps if/when those become useful — only the 9.x line.

## Changes

`renovate.json`: add a `packageRule` matching `gradle-wrapper` manager with `allowedVersions: '< 9.0'` and a description explaining the Java 17 gate.

## Test plan

- [x] `python3 -m json.tool renovate.json` — parses cleanly
- [ ] After merge: Renovate's next scan should auto-close #682 (gradle v9 target outside allowed range)