### PR TITLE
chore: bump sourceCompatibility from 1.8 to 11 (fleet floor alignment)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ subprojects {
     //     exclude "**/*.json"
     // }
 
-    sourceCompatibility = 1.8
+    sourceCompatibility = 11
 
     /* Release Management
      *


### PR DESCRIPTION
Bumps `sourceCompatibility` in `build.gradle` from `1.8` to `11`, matching the workspace fleet floor (per `CLAUDE.md`).

## Why

The CI matrix already runs on Java 11 only (see `.github/workflows/CI.yml`). The `sourceCompatibility = 1.8` pin was just a stale relic, but it had a concrete cost: Gradle resolves dependencies looking for Java 8 class-file variants, and modern artifact majors don't publish those anymore.

Three of the four currently-failing Renovate PRs surface this:

- **#684 guava v33** — guava 32+ made Java 11 the floor; under `sourceCompatibility = 1.8` Gradle reports *'No matching variant ... compatible with Java 8'*
- **#680 jackson-core v2.21.3** — same Gradle-variant-selection failure
- **#673 guava v32.1.3-jre** — same root cause as #684 (superseded by it)

Once this PR lands, those three should pass naturally. (#685 jsonpath v3 still fails — it requires Java 17; it'll be capped via a separate `renovate.json` PR.)

## Changes

`build.gradle`:
- `sourceCompatibility = 1.8` → `sourceCompatibility = 11`.

`targetCompatibility` is not pinned separately; Gradle defaults it to `sourceCompatibility`, so the bytecode target moves to 11 too.

## Test plan

- [x] `./gradlew clean build -x test` — green
- [ ] CI on Java 11 matrix — should still pass (matrix already pins 11)
- [ ] After merge: re-run CI on the failing Renovate PRs (#684, #680, #673) and verify they go green