### PR TITLE
chore: cap com.jayway.jsonpath:json-path Renovate to < 3 (Java 17 floor)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -61,6 +61,11 @@
       "matchManagers": ["gradle-wrapper"],
       "allowedVersions": "< 9.0",
       "description": "Gradle 9 requires Java 17; this portlet builds on the fleet's Java 11 floor. Revisit when the fleet moves to Java 17 (gated on the Spring 6 / Jakarta EE migration)."
+    },
+    {
+      "matchPackageNames": ["com.jayway.jsonpath:json-path"],
+      "allowedVersions": "< 3.0",
+      "description": "json-path 3.x raised its build-time floor to Java 17 and only publishes Java 17+ class-file variants. This portlet builds on the fleet's Java 11 floor. Revisit when the fleet moves to Java 17."
     }
   ]
 }


### PR DESCRIPTION
Stops Renovate from creating PRs that bump `com.jayway.jsonpath:json-path` to 3.x. Most recently surfaced as #685 which has been sitting unmergeable.

## Why

json-path 3.x raised its build-time floor to **Java 17** and only publishes Java 17+ class-file variants. NotificationPortlet builds on the fleet's **Java 11** floor (per the workspace `CLAUDE.md`), so any 3.x bump fails Gradle dependency resolution with *'No matching variant ... compatible with Java X'* before reaching compile.

Same shape as the existing Spring 5+, Hibernate 6+, Jakarta, and Gradle 9 caps already in this file: revisit once the fleet moves to Java 17 as part of the Spring 6 / Jakarta EE migration.

This is independent of #687 (`sourceCompatibility = 11`). #687 unblocks Guava 33 and the Jackson patch line — those publish Java 11 variants. json-path 3 needs the full Java 17 jump.

## Changes

`renovate.json`: add a `packageRule` for `com.jayway.jsonpath:json-path` with `allowedVersions: '< 3.0'` and a description explaining the Java 17 gate.

## Test plan

- [x] `python3 -m json.tool renovate.json` — parses cleanly
- [ ] After merge: Renovate's next scan should auto-close #685