### PR TITLE
fix: point uploadArchives at Central Portal staging URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,10 @@ subprojects {
             mavenDeployer {
                 beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-                repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+                // OSSRH oss.sonatype.org was sunset in June 2025; uploads now go
+                // to the Central Portal's compatibility staging URL. The same
+                // change shipped in uportal-portlet-parent v48 for Maven repos.
+                repository(url: "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/") {
                     authentication(userName: publishingUsername, password: publishingPassword)
                 }
 


### PR DESCRIPTION
Unblocks the 4.8.1 release. Today's `./gradlew release` failed with:

```
> Could not transfer artifact org.jasig.portlet.notification:notification-portlet-api:jar:4.8.1
  from/to remote (https://oss.sonatype.org/service/local/staging/deploy/maven2/):
  Failed to transfer file ...
  Return code is: 402, ReasonPhrase: Payment Required.
```

`oss.sonatype.org` was sunset by Sonatype in June 2025. Uploads to that host now return HTTP 402 as the deprecation signal — Central Portal is the new home.

The same URL change shipped fleet-wide in [uportal-portlet-parent v48](https://github.com/uPortal-Project/uportal-portlet-parent/releases/tag/uportal-portlet-parent-48) for Maven repos. This lands the equivalent for the Gradle `uploadArchives` path here.

## Changes

`build.gradle`:
- `uploadArchives` repository URL: `https://oss.sonatype.org/service/local/staging/deploy/maven2/` → `https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/`
- Comment above the URL records the OSSRH sunset context.

The existing `publishingUsername` / `publishingPassword` credentials in `~/.gradle/gradle.properties` continue to work — the credentials format is unchanged, only the host changed.

## Test plan

- [x] `./gradlew clean build -x test` — green
- [ ] After merge: rerun `./gradlew release` for 4.8.1; uploadArchives should reach the Central Portal staging API
- [ ] Trigger Central Portal upload via the same curl POST used for parent v49/v50/v51 (`/manual/upload/defaultRepository/org.jasig.portlet.notification`)