### PR TITLE
fix: disable plain jar task in webapp module to match prior release layout

### DIFF
--- a/notification-portlet-webapp/build.gradle
+++ b/notification-portlet-webapp/build.gradle
@@ -19,6 +19,18 @@ apply plugin: 'eclipse-wtp'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'war'
 
+// We deploy this module as a WAR (the Pluto-deployable portlet) plus a
+// secondary classesJar (classifier 'jar') consumed by adopters extending
+// the project. The plain `jar` task (auto-enabled by the war + java
+// plugins, then re-packaged by Spring Boot 1.x's bootRepackage) would
+// otherwise produce a third `<artifactId>-<ver>.jar`. That artifact has
+// never been part of a notification-portlet-webapp release on Maven
+// Central (verified against 4.8.0's central layout) and the Central
+// Portal upload validator rejects manifests referencing a primary `.jar`
+// that doesn't reach the staging area. Disable the plain jar task so the
+// layout matches prior releases and the upload validates cleanly.
+jar.enabled = false
+
 configurations {
     providedRuntime
 }


### PR DESCRIPTION
Unblocks the 4.8.1 release. The Central Portal upload validator rejected today's release attempt with:

```
Failed to process deployment: Error on building manifests:
File with path '/tmp/.../notification-portlet-webapp/4.8.1/
  notification-portlet-webapp-4.8.1.jar' is missing
```

## Root cause

`notification-portlet-webapp` is packaged as a `war` but the `war` + `java` plugin combination auto-enables a plain `jar` task. With Spring Boot 1.5.22's plugin in the chain, that produces an executable `.jar` alongside the `.war`. Gradle's old `maven` plugin saw it and listed it in the upload manifest, but the file didn't reach the staging area cleanly — so the Central Portal validator failed.

## Verified against the 4.8.0 layout on Maven Central

```
notification-portlet-webapp-4.8.0.pom
notification-portlet-webapp-4.8.0.war
notification-portlet-webapp-4.8.0-jar.jar         ← the classesJar (classifier 'jar')
notification-portlet-webapp-4.8.0-javadoc.jar
notification-portlet-webapp-4.8.0-sources.jar
```

**No plain `.jar`.** Something previously suppressed it has regressed somewhere in the build.gradle history. Reasserting `jar.enabled = false` locks the layout back to 4.8.0's shape.

This is Spring Boot 1.5.22 — `bootJar` as a property was added in Spring Boot 2.0, so the plain `jar` task is the right knob in 1.x.

## Changes

`notification-portlet-webapp/build.gradle`:
- Add `jar.enabled = false` with a comment explaining the Central Portal manifest constraint.

## Test plan

- [x] `./gradlew clean build -x test` — green
- [x] `build/libs` layout: war + jar-classifier + javadoc + sources, no plain `.jar` (matches 4.8.0)
- [ ] After merge: rerun `./gradlew release` from a clean state
- [ ] After staging: trigger Central Portal upload via `/manual/upload/defaultRepository/org.jasig.portlet.notification`