### PR TITLE
fix: drop dead logback ContextDetachingSCL listener from web.xml

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.jasig.portlet.notification
-version=4.8.2-SNAPSHOT
+version=4.8.2
 
 # Matches (apparently) Spring Boot 1.5.10.RELEASE
 springVersion=4.3.30.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.jasig.portlet.notification
-version=4.8.1-SNAPSHOT
+version=4.8.1
 
 # Matches (apparently) Spring Boot 1.5.10.RELEASE
 springVersion=4.3.30.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.jasig.portlet.notification
-version=4.8.1
+version=4.8.2-SNAPSHOT
 
 # Matches (apparently) Spring Boot 1.5.10.RELEASE
 springVersion=4.3.30.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.jasig.portlet.notification
-version=4.8.2
+version=4.8.3-SNAPSHOT
 
 # Matches (apparently) Spring Boot 1.5.10.RELEASE
 springVersion=4.3.30.RELEASE

--- a/notification-portlet-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/notification-portlet-webapp/src/main/webapp/WEB-INF/web.xml
@@ -26,11 +26,6 @@
     <display-name>Notification Portlet</display-name>
     <description>JSR-286 (Portlet 2.0) portlet to display important notices from campus systems</description>
 
-    <!-- Needed to remove JMX registration and allow for classloader GC -->
-    <listener>
-        <listener-class>ch.qos.logback.classic.selector.servlet.ContextDetachingSCL</listener-class>
-    </listener>
-
     <servlet>
         <servlet-name>ViewRendererServlet</servlet-name>
         <servlet-class>org.springframework.web.servlet.ViewRendererServlet</servlet-class>


### PR DESCRIPTION
## Problem

\`notification-portlet-webapp/src/main/webapp/WEB-INF/web.xml\` registers \`ch.qos.logback.classic.selector.servlet.ContextDetachingSCL\` as a servlet context listener. That class was part of Logback's J2EE selector machinery and **was removed from Logback in 1.3.x**.

Today the listener still loads cleanly because the bundled Spring Boot 1.5.22 ships Logback 1.1.11, which still has the class. But every other portlet in the fleet that bumped Logback to 1.3+ during the 2026-05 release wave hit \`ClassNotFoundException\` at context startup with this exact listener — and NotificationPortlet would hit the same wall the moment its Spring Boot / Logback gets bumped.

The listener also has no functional value here. The comment *"Needed to remove JMX registration and allow for classloader GC"* predates Logback's modern auto-cleanup, and Spring Boot's logging auto-config handles teardown.

## Changes

- **\`notification-portlet-webapp/src/main/webapp/WEB-INF/web.xml\`**: remove the \`<listener>ContextDetachingSCL</listener>\` block plus its outdated explanatory comment.

## Out of scope

- Full Logback / Spring Boot modernization (Spring Boot 1.5.22 → 2.7.x or 3.x) is a separate, much larger discussion. Spring Boot 1.5 ships Logback 1.1.x, slf4j 1.7.x, and bumping just Logback in isolation breaks Boot's auto-config — the version is effectively pinned by the Spring Boot generation. Tracked outside this patch.

## Test plan

- [x] \`./gradlew clean install\` succeeds locally on Java 11
- [x] Same listener removal pattern that landed across the rest of the fleet during the 2026-05 wave (uPortal core PR coming, Announcements, Calendar 2.7.2, JasigWidget 2.4.2, NewsReader 5.1.4, SimpleContent 3.4.2)
- [ ] CI green
- [ ] Post-merge: \`mvn release:clean release:prepare release:perform\` for 4.8.3 (or include in the next release)