### PR TITLE
fix(deps): pin jjwt-impl + jjwt-jackson at runtime (fixes /api/v2 403)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.jasig.portlet.notification
-version=4.8.3
+version=4.8.4-SNAPSHOT
 
 # Matches (apparently) Spring Boot 1.5.10.RELEASE
 springVersion=4.3.30.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.jasig.portlet.notification
-version=4.8.3-SNAPSHOT
+version=4.8.3
 
 # Matches (apparently) Spring Boot 1.5.10.RELEASE
 springVersion=4.3.30.RELEASE

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,11 @@ jacksonDatabindVersion=2.21.3
 jacksonVersion=2.21
 janinoVersion=3.1.12
 jasyptVersion=1.9.3
+# Match the jjwt version pulled in transitively by uPortal-soffit-core.
+# jjwt-api ships through that chain on the compile classpath, but jjwt-impl
+# and jjwt-jackson are runtimeOnly there, so they don't propagate to this
+# project automatically — declare them directly below.
+jjwtVersion=0.11.5
 jodaTimeVersion=2.14.2
 jsonPathVersion=2.10.0
 jsonSmartVersion=2.6.0

--- a/notification-portlet-webapp/build.gradle
+++ b/notification-portlet-webapp/build.gradle
@@ -68,6 +68,16 @@ dependencies {
     compile "org.hibernate:hibernate-entitymanager:${hibernateVersion}"
     compile "org.jasig.resourceserver:resource-server-utils:${resourceServerVersion}"
     compile("org.jasig.portal:uPortal-soffit-renderer:${uPortalVersion}")
+    /*
+     * uPortal-soffit-core declares jjwt-impl and jjwt-jackson as
+     * runtimeOnly — Gradle does not propagate runtimeOnly transitives
+     * through `compile`, so without these explicit declarations the
+     * deployed WAR ships only jjwt-api and `Jwts.parser()` throws
+     * UnknownClassException on first call, breaking the OIDC-protected
+     * /api/v2/notifications endpoint with a 403.
+     */
+    runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"
+    runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jjwtVersion}"
     compile "org.jasig.portal:uPortal-spring:${uPortalVersion}@jar" // Use @jar classifier to exclude transitive dependencies
     compile "org.jasypt:jasypt-spring31:${jasyptVersion}"
     compile "org.springframework:spring-jdbc:${springVersion}"


### PR DESCRIPTION
## Problem

Every request to `/NotificationPortlet/api/v2/notifications` returns **403 Forbidden** in 4.8.x deployments even when the caller sends a valid uPortal-issued OIDC bearer token. Both the `<notification-icon>` and `<notification-list>` web components power their UI off this endpoint, so they silently render empty in the portal.

The 403 is logged on the server as:

```
INFO  o.a.p.s.s.SoffitApiPreAuthenticatedProcessingFilter
  - The following Bearer token is unusable: 'eyJhbGciOiJIUzUxMiJ9...'
```

The actual exception only surfaces if you turn `org.apereo.portal.soffit.security` to DEBUG:

```
io.jsonwebtoken.lang.UnknownClassException: Unable to load class named
[io.jsonwebtoken.impl.DefaultJwtParser] from the thread context, current,
or system/application ClassLoaders.  All heuristics have been exhausted.
Class could not be found.  Have you remembered to include the jjwt-impl.jar
in your runtime classpath?
```

## Root cause

`WEB-INF/lib` of the deployed 4.8.x WAR contains **only** `jjwt-api-0.11.5.jar`. JJWT 0.10+ split into three artifacts:

- `jjwt-api` — interfaces (compile-time)
- `jjwt-impl` — runtime implementation (`DefaultJwtParser` lives here)
- `jjwt-jackson` — JSON parsing

`uPortal-soffit-core` (the chain that brings JJWT into this project) declares the impl and jackson artifacts as `runtimeOnly`. Gradle does **not** propagate `runtimeOnly` transitive dependencies through the deprecated `compile` configuration this project still uses, so neither impl nor jackson lands in this WAR's runtime classpath. `Jwts.parser()` throws on first call → the filter swallows that as "Bearer token is unusable" → Spring Security returns 403.

## Fix

Declare the runtime jars directly in `notification-portlet-webapp/build.gradle`:

```gradle
runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"
runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jjwtVersion}"
```

Pin `jjwtVersion=0.11.5` in `gradle.properties` to match the version `uPortal-soffit-core` ships transitively (`jjwt-api-0.11.5.jar` is what's already on the classpath today).

## Verification

Redeployed against uPortal-start with `notificationPortletVersion=4.8.4-SNAPSHOT`:

- Before: `GET /NotificationPortlet/api/v2/notifications` → 403, body empty, components render nothing.
- After: 200 OK, body is the expected JSON array of notifications. The `<notification-list>` portlet renders the demo entries (Room Available, Bike License Ticket, Past Due Book, Advanced Computer Engineering 524, Math 101, …). The `<notification-icon>` badge shows a non-zero unread count.

I added a Playwright regression guard in `uPortal-start`'s suite at `tests/ux/portlets/notifications.spec.ts` that asserts (a) the demo titles render in the DOM and (b) the API rejects missing/garbage bearer tokens with 403 — so a future regression in the runtime-classpath plumbing or in Spring Security itself fails loudly.

## Notes

- Considered fixing this upstream by changing `uPortal-soffit-core` to declare the jars as `api` instead of `runtimeOnly`. Decided against — that pollutes every consumer's compile classpath with implementation jars they shouldn't need at compile time. The right place is the consumer module that actually exercises `Jwts.parser()`.
- The release plugin commits at HEAD already moved the version to `4.8.4-SNAPSHOT`, so this PR ships against that.