### PR TITLE
Upgrade/jjwt 0.13.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,11 +23,12 @@ jacksonDatabindVersion=2.21.3
 jacksonVersion=2.21
 janinoVersion=3.1.12
 jasyptVersion=1.9.3
-# Match the jjwt version pulled in transitively by uPortal-soffit-core.
-# jjwt-api ships through that chain on the compile classpath, but jjwt-impl
-# and jjwt-jackson are runtimeOnly there, so they don't propagate to this
-# project automatically — declare them directly below.
-jjwtVersion=0.11.5
+# JJWT 0.12+ overhauled the API (builder-based parser, getPayload() instead
+# of getBody(), SecretKey instead of raw String signing keys, etc.).
+# jjwt-api must be declared explicitly to override the older transitive
+# version pulled in through uPortal-soffit-core; jjwt-impl and jjwt-jackson
+# remain runtimeOnly (Gradle does not propagate runtimeOnly transitives).
+jjwtVersion=0.13.0
 jodaTimeVersion=2.14.2
 jsonPathVersion=2.10.0
 jsonSmartVersion=2.6.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,7 +40,7 @@ romeVersion=2.1.0
 servletApiVersion=2.5
 slf4jVersion=2.0.18
 springfoxVersion=2.9.2
-uPortalVersion=5.17.9
+uPortalVersion=5.17.10-SNAPSHOT
 annotationApiVersion=1.3.2
 jaxbApiVersion=2.3.1
 

--- a/notification-portlet-webapp/build.gradle
+++ b/notification-portlet-webapp/build.gradle
@@ -67,15 +67,17 @@ dependencies {
     }
     compile "org.hibernate:hibernate-entitymanager:${hibernateVersion}"
     compile "org.jasig.resourceserver:resource-server-utils:${resourceServerVersion}"
-    compile("org.jasig.portal:uPortal-soffit-renderer:${uPortalVersion}")
+    compile("org.jasig.portal:uPortal-soffit-renderer:${uPortalVersion}") {
+        // Exclude the older jjwt-api pulled in transitively so our explicit
+        // version (0.13.0) wins without Gradle conflict-resolution ambiguity.
+        exclude group: 'io.jsonwebtoken', module: 'jjwt-api'
+    }
     /*
-     * uPortal-soffit-core declares jjwt-impl and jjwt-jackson as
-     * runtimeOnly — Gradle does not propagate runtimeOnly transitives
-     * through `compile`, so without these explicit declarations the
-     * deployed WAR ships only jjwt-api and `Jwts.parser()` throws
-     * UnknownClassException on first call, breaking the OIDC-protected
-     * /api/v2/notifications endpoint with a 403.
+     * JJWT 0.13.0 — all three modules must be at the same version.
+     * jjwt-api is needed on the compile classpath (new builder/parser API);
+     * jjwt-impl and jjwt-jackson are runtime service-provider jars.
      */
+    compile "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
     runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"
     runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jjwtVersion}"
     compile "org.jasig.portal:uPortal-spring:${uPortalVersion}@jar" // Use @jar classifier to exclude transitive dependencies

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jdbc/AbstractJdbcNotificationService.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/jdbc/AbstractJdbcNotificationService.java
@@ -38,6 +38,9 @@ import javax.sql.DataSource;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
 import net.sf.ehcache.Cache;
 import net.sf.ehcache.Element;
 import org.apache.commons.lang3.StringUtils;
@@ -194,11 +197,12 @@ public abstract class AbstractJdbcNotificationService extends AbstractNotificati
 
         try {
             // Validate & parse the JWT
+            final SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(signatureKey));
             final Jws<Claims> claims =
-                    Jwts.parser().setSigningKey(signatureKey).parseClaimsJws(bearerToken);
+                    Jwts.parser().verifyWith(key).build().parseSignedClaims(bearerToken);
             // Convert to MapSqlParameterSource
             Map<String,Object> map = new HashMap<>();
-            claims.getBody().entrySet()
+            claims.getPayload().entrySet()
                     .forEach(entry -> {
                         final Object value = entry.getValue();
                         if (List.class.isInstance(value) && ((List<Object>)value).size() != 0) {

--- a/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/rest/UserAttributeParameterEvaluator.java
+++ b/notification-portlet-webapp/src/main/java/org/jasig/portlet/notice/service/rest/UserAttributeParameterEvaluator.java
@@ -21,6 +21,9 @@ package org.jasig.portlet.notice.service.rest;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import javax.crypto.SecretKey;
 import org.apache.commons.lang3.StringUtils;
 import org.apereo.portal.soffit.Headers;
 import org.slf4j.Logger;
@@ -83,7 +86,7 @@ public class UserAttributeParameterEvaluator extends AbstractParameterEvaluator 
 
         final Jws<Claims> oidcToken = parseOidcToken(req);
         if (oidcToken != null) {
-            final Object claimValue = oidcToken.getBody().get(claimName);
+            final Object claimValue = oidcToken.getPayload().get(claimName);
 
             if (claimValue == null) {
                 //
@@ -130,8 +133,9 @@ public class UserAttributeParameterEvaluator extends AbstractParameterEvaluator 
 
         try {
             // Validate & parse the JWT
+            final SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(signatureKey));
             final Jws<Claims> rslt =
-                    Jwts.parser().setSigningKey(signatureKey).parseClaimsJws(bearerToken);
+                    Jwts.parser().verifyWith(key).build().parseSignedClaims(bearerToken);
 
             logger.debug("Found the following OIDC Id token:  {}", rslt.toString());
 


### PR DESCRIPTION
    fix(deps): upgrade jjwt from 0.11.5 to 0.13.0

    Migrate to the JJWT 0.12+ API:
    - Use Keys.hmacShaKeyFor(Decoders.BASE64.decode(...)) for signing keys
    - Replace parseClaimsJws() with parseSignedClaims()
    - Replace getBody() with getPayload()
    - Exclude older transitive jjwt-api from uPortal-soffit-renderer
    - Declare jjwt-api explicitly on compile classpath
    
    Note that this'll need 5.17.10 of uPortal released and the SNAPSHOT removed.